### PR TITLE
fix: harden engine database and setup audit findings

### DIFF
--- a/ares/core/engine.py
+++ b/ares/core/engine.py
@@ -464,6 +464,7 @@ class AresEngine:
         skip_validation:    bool = False,
         timeout_per_module: int  = 120,
         on_progress:        ProgressCallback | None = None,
+        actor_role:         str = "operator",
     ) -> dict[str, EngineModuleResult]:
         """
         Run all stages.
@@ -493,6 +494,7 @@ class AresEngine:
                     timeout_seconds=timeout_per_module,
                     stage_name=name,
                     on_progress=on_progress,
+                    actor_role=actor_role,
                 )
                 for mid in module_ids
             ]
@@ -741,6 +743,7 @@ class AresEngine:
         timeout_seconds: int,
         stage_name:      str,
         on_progress:     ProgressCallback | None,
+        actor_role:      str,
     ) -> EngineModuleResult:
         if self._semaphore is None:
             raise RuntimeError(

--- a/ares/db/database.py
+++ b/ares/db/database.py
@@ -288,8 +288,10 @@ class AresDatabase:
             INSERT INTO campaigns(id,name,client,operator,noise_profile,status,scope_json,targets_json,notes)
             VALUES(?,?,?,?,?,?,?,?,?)
             ON CONFLICT(id) DO UPDATE SET
-              name=excluded.name, client=excluded.client, status=excluded.status,
-              targets_json=excluded.targets_json, notes=excluded.notes,
+              name=excluded.name, client=excluded.client, operator=excluded.operator,
+              noise_profile=excluded.noise_profile, status=excluded.status,
+              scope_json=excluded.scope_json, targets_json=excluded.targets_json,
+              notes=excluded.notes,
               updated_at=datetime('now')
         """, (c.id, c.name, c.client, c.operator, c.noise_profile.value,
               c.status.value if hasattr(c.status, 'value') else str(c.status),

--- a/ares/db/postgres.py
+++ b/ares/db/postgres.py
@@ -293,8 +293,10 @@ class PostgresDatabase:
                 INSERT INTO campaigns(id,name,client,operator,noise_profile,status,scope_json,targets_json,notes)
                 VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9)
                 ON CONFLICT(id) DO UPDATE SET
-                  name=EXCLUDED.name, client=EXCLUDED.client, status=EXCLUDED.status,
-                  targets_json=EXCLUDED.targets_json, notes=EXCLUDED.notes,
+                  name=EXCLUDED.name, client=EXCLUDED.client, operator=EXCLUDED.operator,
+                  noise_profile=EXCLUDED.noise_profile, status=EXCLUDED.status,
+                  scope_json=EXCLUDED.scope_json, targets_json=EXCLUDED.targets_json,
+                  notes=EXCLUDED.notes,
                   updated_at=now()
             """, c.id, c.name, c.client, c.operator,
                 c.noise_profile.value if hasattr(c.noise_profile, "value") else str(c.noise_profile),

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -30,8 +30,23 @@ if [ ! -f ".env" ]; then
     cp .env.example .env
     SECRET=$(python3 -c "import secrets; print(secrets.token_hex(32))")
     ENC=$(python3 -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())")
-    sed -i "s|ARES_SECRET_KEY=CHANGE_ME.*|ARES_SECRET_KEY=$SECRET|" .env
-    sed -i "s|ARES_ENCRYPTION_KEY=CHANGE_ME.*|ARES_ENCRYPTION_KEY=$ENC|" .env
+    ARES_GENERATED_SECRET="$SECRET" ARES_GENERATED_ENC="$ENC" python3 - <<'PY'
+import os
+from pathlib import Path
+
+updates = {
+    "ARES_SECRET_KEY=": f"ARES_SECRET_KEY={os.environ['ARES_GENERATED_SECRET']}",
+    "ARES_ENCRYPTION_KEY=": f"ARES_ENCRYPTION_KEY={os.environ['ARES_GENERATED_ENC']}",
+}
+env_path = Path(".env")
+lines = env_path.read_text(encoding="utf-8").splitlines()
+for index, line in enumerate(lines):
+    for prefix, value in updates.items():
+        if line.startswith(prefix):
+            lines[index] = value
+            break
+env_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+PY
     echo "[!] .env created - set ARES_DEFAULT_ADMIN_PASSWORD before starting"
 fi
 

--- a/tests/unit/test_core_infrastructure.py
+++ b/tests/unit/test_core_infrastructure.py
@@ -71,6 +71,33 @@ class TestAresDatabase:
         assert row["client"] == "ACME"
 
     @pytest.mark.asyncio
+    async def test_save_campaign_upsert_refreshes_persisted_fields(self, db):
+        """Saving an existing campaign should refresh every persisted campaign field."""
+        import json
+        from ares.core.campaign import Campaign, NoiseProfile, ScopeEntry
+
+        c = Campaign(
+            name="TestOp", client="ACME", operator="tester",
+            scope=[ScopeEntry(cidr="10.0.0.0/24")],
+            noise_profile=NoiseProfile.NORMAL,
+            targets=["10.0.0.5"],
+        )
+        await db.save_campaign(c)
+
+        c.operator = "second-operator"
+        c.noise_profile = NoiseProfile.AGGRESSIVE
+        c.scope = [ScopeEntry(cidr="192.168.10.0/24")]
+        c.targets = ["192.168.10.5"]
+        await db.save_campaign(c)
+
+        row = await db.get_campaign(c.id)
+        assert row is not None
+        assert row["operator"] == "second-operator"
+        assert row["noise_profile"] == NoiseProfile.AGGRESSIVE.value
+        assert json.loads(row["scope_json"])[0]["cidr"] == "192.168.10.0/24"
+        assert json.loads(row["targets_json"]) == ["192.168.10.5"]
+
+    @pytest.mark.asyncio
     async def test_get_nonexistent_campaign(self, db):
         """Fetching a campaign that doesn't exist should return None."""
         row = await db.get_campaign("nonexistent-id")


### PR DESCRIPTION
## Summary

This PR contains follow-up hardening fixes from a bounded deep code-health audit.

Fixed areas:
- Hardened engine plan execution so `actor_role` is preserved through guarded execution.
- Fixed campaign database upsert drift so SQLite/Postgres refresh persisted campaign fields consistently.
- Improved `scripts/setup.sh` portability by removing GNU `sed -i` dependency and using portable inline Python for env-file mutation.
- Added regression coverage for campaign upsert field refresh behavior.

## Validation

Local validation completed successfully:

```text
bash -n scripts/setup.sh
passed

python -m compileall ares tests
passed

pytest tests/unit/test_module_execute_adapters.py -q --tb=short --timeout=60 --timeout-method=thread
13 passed

pytest tests/unit/test_state_graph_fingerprint_service.py::TestPackageExports -q --tb=short --timeout=60 --timeout-method=thread
9 passed

pytest tests/unit/test_engine.py -q --tb=short --timeout=60 --timeout-method=thread
7 passed

pytest tests/unit/test_strategy_engine.py -q --tb=short --timeout=60 --timeout-method=thread
37 passed

pytest tests/unit/test_api_endpoints.py -q --tb=short --timeout=60 --timeout-method=thread
32 passed

pytest tests/unit/test_core_infrastructure.py::TestAresDatabase::test_save_campaign_upsert_refreshes_persisted_fields -q --tb=short --timeout=60 --timeout-method=thread
1 passed

pytest tests/unit/test_core_infrastructure.py::TestAresDatabase -q --tb=short --timeout=60 --timeout-method=thread
17 passed
```

```text
.\.venv\Scripts\python -m pytest tests\unit -q --tb=short --timeout=60 --timeout-method=thread --maxfail=1

1103 passed, 94 warnings in 129.47s
```