### PR TITLE
fix: wire SDK timeout decorator to runtime timeout

### DIFF
--- a/ares/modules/sdk.py
+++ b/ares/modules/sdk.py
@@ -193,6 +193,7 @@ def timeout(seconds: int) -> Any:
             ...
     """
     def decorator(cls: type) -> type:
+        cls.MODULE_TIMEOUT_SECONDS = seconds
         cls.DEFAULT_TIMEOUT_S = seconds
         return cls
     return decorator

--- a/tests/unit/test_sdk_public_api.py
+++ b/tests/unit/test_sdk_public_api.py
@@ -53,6 +53,16 @@ def test_module_metadata_decorator_available_from_public_sdk() -> None:
     assert sdk.validate_module_class(DemoModule) == []
 
 
+def test_timeout_decorator_sets_runtime_timeout_contract() -> None:
+    @sdk.timeout(42)
+    class DemoModule(sdk.BaseModule):
+        async def run(self, **kwargs):
+            return [], {"ok": True}
+
+    assert DemoModule.MODULE_TIMEOUT_SECONDS == 42
+    assert DemoModule.DEFAULT_TIMEOUT_S == 42
+
+
 @pytest.mark.asyncio
 async def test_module_test_helper_available_from_public_sdk() -> None:
     @sdk.module_metadata(


### PR DESCRIPTION
## Summary

This PR fixes a confirmed SDK/public API runtime contract mismatch.

Fixed issue:
- `@timeout(seconds)` public SDK decorator previously set `DEFAULT_TIMEOUT_S`, but the runtime engine reads `MODULE_TIMEOUT_SECONDS`.
- The decorator now sets `MODULE_TIMEOUT_SECONDS = seconds`.
- `DEFAULT_TIMEOUT_S = seconds` is preserved for backward compatibility.
- Added focused regression coverage proving both timeout attributes are set.

## Validation

```text
python -m compileall ares tests
passed

pytest tests/unit/test_sdk_public_api.py -q --tb=short --timeout=60 --timeout-method=thread
5 passed

pytest tests/unit/test_state_graph_fingerprint_service.py::TestPackageExports -q --tb=short --timeout=60 --timeout-method=thread
9 passed

pytest tests/unit -q --tb=short --timeout=60 --timeout-method=thread --maxfail=1
1104 passed, 94 warnings

```