### PR TITLE
docs: clean root config and setup guidance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# ─── ARES Environment Variables ───────────────────────────────────────────────
+# ARES Environment Variables
 # Copy this to .env and fill in your values. NEVER commit .env to git.
 
 # API Security
@@ -11,7 +11,7 @@ ARES_API_PORT=8080
 ARES_DEBUG=false
 
 # JWT Algorithm
-# HS256 (default, symmetric): sign + verify with ARES_SECRET_KEY — suitable for single-service
+# HS256 (default, symmetric): sign + verify with ARES_SECRET_KEY - suitable for single-service
 # RS256 (asymmetric RSA):     sign with private key, verify with public key
 #   Recommended for multi-service: distribute only the public key to verifier services
 #   Generate keypair:
@@ -23,7 +23,7 @@ ARES_JWT_EXPIRE_MINUTES=60
 # ARES_JWT_PUBLIC_KEY_PATH=/run/secrets/ares_jwt_public.pem     # RS256 only
 
 # Database
-# SQLite (default — no setup required, single-node)
+# SQLite (default - no setup required, single-node)
 ARES_DATABASE_URL=sqlite+aiosqlite:///./ares.db
 #
 # PostgreSQL (multi-operator production deployments)
@@ -40,13 +40,13 @@ ARES_DATABASE_URL=sqlite+aiosqlite:///./ares.db
 #   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 ARES_ENCRYPTION_KEY=CHANGE_ME_USE_Fernet_generate_key
 
-# Legacy encryption salt — for DataEncryptor records written before v6
+# Legacy encryption salt - for DataEncryptor records written before v6
 # Only set if you rotated the default salt in a previous deployment.
 # Changing this makes all pre-v6 encrypted records unreadable.
 # Default (if unset): built-in v5 fixed salt is used automatically.
 # ARES_LEGACY_SALT=your-custom-legacy-salt-here
 
-# Legacy vault salt — for CredentialVault records written before v6
+# Legacy vault salt - for CredentialVault records written before v6
 # ARES_VAULT_LEGACY_SALT=your-custom-vault-legacy-salt-here
 
 # Logging
@@ -61,14 +61,14 @@ ARES_DEFAULT_NOISE_PROFILE=stealth
 ARES_DEFAULT_JITTER_MIN_MS=500
 ARES_DEFAULT_JITTER_MAX_MS=3000
 
-# ── Webhook Notifications (optional) ──────────────────────────────────────────
+# Webhook Notifications (optional)
 # Slack/Teams/generic webhook URL. Leave blank to disable webhook notifications.
 ARES_WEBHOOK_URL=
 ARES_WEBHOOK_ON_SEVERITY=critical,high    # Severities to alert on
 ARES_WEBHOOK_TIMEOUT=5.0                  # HTTP timeout seconds
 ARES_WEBHOOK_RETRY=2                      # Max retries on failure
 
-# ── Network Security ──────────────────────────────────────────────────────────
+# Network Security
 # Comma-separated allowed CORS origins (no wildcard)
 # Dev default: localhost only. Production: set to your actual domain.
 #   Example: ARES_CORS_ORIGINS=https://ares.corp.local,https://pentest.corp.local
@@ -79,7 +79,7 @@ ARES_CORS_ORIGINS=http://localhost:3000,http://localhost:8080
 #   Example: ARES_TRUSTED_HOSTS=ares.corp.local,10.0.0.5
 ARES_TRUSTED_HOSTS=localhost,127.0.0.1
 
-# ── Bootstrap Admin (change immediately after first startup) ──────────────────
+# Bootstrap Admin (change immediately after first startup)
 # You choose this password. It is only for creating the first admin account.
 # After first login, change it from the Security page.
 ARES_DEFAULT_ADMIN_PASSWORD=YOUR_STRONG_ADMIN_PASSWORD_HERE

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ frontend/dist/
 ares.db
 ares_redteam.egg-info/
 
-# Shadow module dirs — real code lives in ares/ package only
+# Shadow module dirs - real code lives in ares/ package only
 /api/
 !frontend/src/api/
 !frontend/src/api/**

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,11 +6,11 @@
 # freeze to SHA commits by running: pre-commit autoupdate --freeze
 # This replaces version tags like v0.4.4 with immutable commit SHAs.
 #
-# Hooks run on every git commit — catches issues before CI.
+# Hooks run on every git commit - catches issues before CI.
 # To skip once: git commit --no-verify (use sparingly)
 
 repos:
-  # ── Formatting & linting ──────────────────────────────────────────────
+  # Formatting & linting
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.4.4  # frozen: use `pre-commit autoupdate --freeze` to update SHA
     hooks:
@@ -18,7 +18,7 @@ repos:
         args: [--fix]
       - id: ruff-format
 
-  # ── Type checking ─────────────────────────────────────────────────────
+  # Type checking
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.9.0  # frozen: use `pre-commit autoupdate --freeze` to update SHA
     hooks:
@@ -27,7 +27,7 @@ repos:
         additional_dependencies: [pydantic, types-pyyaml]
         files: ^ares/
 
-  # ── Security ──────────────────────────────────────────────────────────
+  # Security
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.8  # frozen: use `pre-commit autoupdate --freeze` to update SHA
     hooks:
@@ -35,7 +35,7 @@ repos:
         args: [-ll, -x, tests/]
         files: ^ares/
 
-  # ── Secret detection ──────────────────────────────────────────────────
+  # Secret detection
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.4.0  # frozen: use `pre-commit autoupdate --freeze` to update SHA
     hooks:
@@ -43,7 +43,7 @@ repos:
         args: [--baseline, .secrets.baseline]
         exclude: (\.env\.example|requirements-lock\.txt|CHANGELOG\.md)
 
-  # ── General file hygiene ──────────────────────────────────────────────
+  # General file hygiene
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0  # frozen: use `pre-commit autoupdate --freeze` to update SHA
     hooks:
@@ -57,7 +57,7 @@ repos:
       - id: debug-statements
       - id: detect-private-key
 
-  # ── Commit message convention (Conventional Commits) ──────────────────
+  # Commit message convention (Conventional Commits)
   # feat: / fix: / docs: / security: / refactor: / test: / chore:
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v3.2.0  # frozen: use `pre-commit autoupdate --freeze` to update SHA

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ---
 
-## [6.0.0] — 2026-03-21
+## [6.0.0] - 2026-03-21
 
 ### The story behind v6
 
-v5 worked. It got the job done — enumerate, kerberoast, maybe dcsync if you were lucky.
+v5 worked. It got the job done - enumerate, kerberoast, maybe dcsync if you were lucky.
 But it was a script runner with a CLI bolted on. Every engagement looked the same.
 Every operator had to make the same manual decisions. And when defenders got better,
 the static playbooks started failing.
@@ -18,7 +18,7 @@ Three things forced the rewrite:
 
 **Defenders got smarter.** By 2024, mature EDR deployments were catching static sequences
 reliably. A tool that runs the same order every time is a known signature. OPSEC needed
-to be baked into every layer — not an afterthought.
+to be baked into every layer - not an afterthought.
 
 **Engagements got more complex.** Multi-cloud + hybrid AD + container environments mean
 an operator can't mentally track all the attack paths anymore. We needed something that
@@ -26,7 +26,7 @@ could hold the state of an engagement and make decisions based on what had alrea
 tried and failed.
 
 **The credential vault gap.** Every red team tool treats credentials as ephemeral.
-Harvest, use, forget. We wanted persistence — a vault that accumulates across the
+Harvest, use, forget. We wanted persistence - a vault that accumulates across the
 engagement, scores by privilege, and automatically feeds downstream modules.
 
 v6 is the answer to those three problems. 60 modules. A goal-based engine. Scope
@@ -43,57 +43,57 @@ But now there's infrastructure under you instead of just a script.
 
 **Core engine**
 - 60 attack modules across 11 categories
-- `StrategyEngine` — multi-round autonomous engagement loop with detection spike protection
-- `ConstitutionEnforcer` — Python-layer safety that LLM prompts cannot bypass
-- `TargetStateMap` — per-host memory across rounds (prevents re-running failed techniques)
-- `OutcomeKnowledgeBase` — quality-weighted learning from module results
+- `StrategyEngine` - multi-round autonomous engagement loop with detection spike protection
+- `ConstitutionEnforcer` - Python-layer safety that LLM prompts cannot bypass
+- `TargetStateMap` - per-host memory across rounds (prevents re-running failed techniques)
+- `OutcomeKnowledgeBase` - quality-weighted learning from module results
 
 **AI & OPSEC**
-- `ai.autonomous_planner` — LLM-powered attack chain (Claude / OpenAI / Ollama)
-- Multi-LLM consensus mode — two LLMs agree = higher confidence plan
-- Adversarial simulation — blue team LLM predicts detection timeline for attack plan
-- `edr.bypass_adaptive` — EDR vendor detection → ranked techniques + live probes + BYOVD
-- `opsec.coverage_predictor` — detection probability with SOC shift model and SIEM correlation
-- Dwell time decay — longer undetected = lower estimated detection risk
-- Pre-execution prediction — score *before* a plan runs, not after
+- `ai.autonomous_planner` - LLM-powered attack chain (Claude / OpenAI / Ollama)
+- Multi-LLM consensus mode - two LLMs agree = higher confidence plan
+- Adversarial simulation - blue team LLM predicts detection timeline for attack plan
+- `edr.bypass_adaptive` - EDR vendor detection -> ranked techniques + live probes + BYOVD
+- `opsec.coverage_predictor` - detection probability with SOC shift model and SIEM correlation
+- Dwell time decay - longer undetected = lower estimated detection risk
+- Pre-execution prediction - score *before* a plan runs, not after
 
 **Cloud**
-- `cloud.identity_federation_abuse` — Golden SAML, SAML/OIDC cross-cloud pivot, GCP WIF
-- Azure Managed Identity enumeration — zero-credential attack path via MI + high-privilege roles
-- GCP Workload Identity Federation — GitHub Actions → GCP service account impersonation
-- Azure B2B cross-tenant enumeration — Midnight Blizzard-style pivot detection
-- Token lifetime abuse detection — CAE status, legacy auth, refresh token policy
+- `cloud.identity_federation_abuse` - Golden SAML, SAML/OIDC cross-cloud pivot, GCP WIF
+- Azure Managed Identity enumeration - zero-credential attack path via MI + high-privilege roles
+- GCP Workload Identity Federation - GitHub Actions -> GCP service account impersonation
+- Azure B2B cross-tenant enumeration - Midnight Blizzard-style pivot detection
+- Token lifetime abuse detection - CAE status, legacy auth, refresh token policy
 
 **Security (audit results)**
 - Engine-level scope pre-check before any module executes
-- DNS-resolving scope guard — fails closed if hostname can't resolve
+- DNS-resolving scope guard - fails closed if hostname can't resolve
 - bcrypt DoS protection on all password fields + `/auth/token` form
 - SQL injection mitigated in `lateral.mssql` (safe_cmd escaping + MSSQLParams schema)
 - Shell injection fixed in `exfil.secrets_scan` and `exfil.staged_collection` (shlex.quote)
 - TOCTOU fixed in `windows.lsass_dump` and `windows.dpapi` (mkstemp)
-- `marketplace/installer.py` — SHA-256 hash verification before file install
-- `worker/cluster.py` — credential params redacted before Redis HSET
+- `marketplace/installer.py` - SHA-256 hash verification before file install
+- `worker/cluster.py` - credential params redacted before Redis HSET
 - GCP project_id pattern validation (blocks path traversal)
 - `ALWAYS_REQUIRE_AUTH` modules require `team_lead` role at API level
 - Concurrent engagement limit (`ARES_MAX_ENGAGEMENTS`, default 3)
 - Campaign ownership check on `/strategy/engage`
 
 **Infrastructure**
-- `POST /strategy/engage` API — start autonomous engagement with full RBAC
-- `GET /strategy/active` — query running engagements and available slots
-- `POST /edr/bypass/report` — operator reports bypass outcomes from the field
+- `POST /strategy/engage` API - start autonomous engagement with full RBAC
+- `GET /strategy/active` - query running engagements and available slots
+- `POST /edr/bypass/report` - operator reports bypass outcomes from the field
 - Cross-session bypass learning via DB persistence (90-day rolling window)
-- `bypass_outcomes` DB table — historical success rates per technique × EDR vendor
+- `bypass_outcomes` DB table - historical success rates per technique x EDR vendor
 - Pydantic validation for all 60 modules (up from 10)
-- `PlanValidator` — catches LLM hallucinated module IDs before engine execution
-- Round narrative injection — LLM sees history of what failed per host
-- Credential actionability formatting — LLM knows which modules to use per credential type
+- `PlanValidator` - catches LLM hallucinated module IDs before engine execution
+- Round narrative injection - LLM sees history of what failed per host
+- Credential actionability formatting - LLM knows which modules to use per credential type
 
 **Developer experience**
 - `ares doctor` with exact fix commands per failure (pyenv, apt, brew, pip)
 - SHA-pinned nginx image in `docker-compose.prod.yml`
 - Pre-commit config with freeze instructions for full supply-chain security
-- QUICKSTART.md — 30-minute lab guide with GOAD setup
+- QUICKSTART.md - local setup and dashboard guide
 - CONTRIBUTING.md, SECURITY.md, MODULE_GUIDE.md
 
 ### Changed
@@ -101,13 +101,13 @@ But now there's infrastructure under you instead of just a script.
 - `[full]` extra now includes `[windows]` (pypykatz for lsass_dump)
 - `[ad]` extra now includes `httpx-ntlm` for ADCS ESC1 HTTP enrollment
 - `[cloud]` extra now includes `msal` for Azure AD device code flow
-- Coverage threshold raised to 85% (roadmap: 90%)
+- Coverage threshold raised to 85%
 - CI: `pip freeze` auto-generates pinned lock file on push to `main`
 
-### v5 → v6 migration
+### v5 -> v6 migration
 
 v5 used a single fixed salt for all encryption. v6 uses per-record PBKDF2-SHA256 (100k iterations).
-Existing v5 data is readable via `ARES_LEGACY_SALT` env var — set this to your v5 salt before migrating.
+Existing v5 data is readable via `ARES_LEGACY_SALT` env var - set this to your v5 salt before migrating.
 
 See `migrations/` for Alembic migration scripts.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to ARES
 
 Thank you for contributing to ARES. This guide covers everything you need
-to get started — from dev environment setup to submitting a pull request.
+to get started - from dev environment setup to submitting a pull request.
 
 ---
 
@@ -24,17 +24,17 @@ to get started — from dev environment setup to submitting a pull request.
 git clone https://github.com/<your-fork>/ares && cd ares
 
 # 2. Create virtual environment
-python -m venv venv && source venv/bin/activate
+python -m venv .venv && source .venv/bin/activate
 
-# 3. Install in dev mode with all extras
-pip install -e ".[full,dev]"
+# 3. Install in dev mode
+pip install -e ".[dev,pdf]"
 
 # 4. Install pre-commit hooks
 pip install pre-commit && pre-commit install
 
 # 5. Copy and configure .env
 cp .env.example .env
-# Edit .env — set ARES_SECRET_KEY and ARES_ENCRYPTION_KEY
+# Edit .env - set ARES_SECRET_KEY, ARES_ENCRYPTION_KEY, and ARES_DEFAULT_ADMIN_PASSWORD
 # Generate: openssl rand -hex 32
 
 # 6. Verify setup
@@ -46,26 +46,25 @@ pytest tests/unit/ -v
 
 ## Branching Strategy
 
-ARES uses Git Flow:
+ARES uses short-lived branches from `main`:
 
 | Branch | Purpose |
 |--------|---------|
-| `main` | Production — protected, requires PR + review |
-| `develop` | Integration branch — PRs target here |
+| `main` | Protected default branch; requires PR + review |
 | `feature/<name>` | New features and modules |
 | `fix/<name>` | Bug fixes |
 | `hotfix/<name>` | Critical fixes that go directly to main |
-| `security/<name>` | Security fixes — keep private until patched |
+| `security/<name>` | Security fixes; keep private until patched |
 
 ```bash
 # Start a new module
-git checkout develop
-git pull origin develop
+git checkout main
+git pull origin main
 git checkout -b feature/ad-my-new-module
 
 # When done
 git push origin feature/ad-my-new-module
-# Open PR targeting develop
+# Open PR targeting main
 ```
 
 ---
@@ -110,8 +109,8 @@ Every ARES module is a class that extends `BaseModule` in `ares/modules/base.py`
 
 ```python
 """
-My Module — category.module_name
-MITRE: T1234 — Technique Name
+My Module - category.module_name
+MITRE: T1234 - Technique Name
 
 One paragraph: what this module does, what it needs, what it produces.
 """
@@ -137,7 +136,7 @@ class MyModule(BaseModule):
     MODULE_TIMEOUT_SECONDS: int | None = None   # override if slow (e.g. 300 for dump)
 
     async def validate(self, ctx: "Any") -> None:
-        """Pre-flight checks — runs before any network call."""
+        """Pre-flight checks - runs before any network call."""
         await super().validate(ctx)
         from ares.core.context import ExecutionContext
         from ares.core.errors import ModuleValidationError
@@ -190,7 +189,7 @@ class MyModule(BaseModule):
         return self._findings[:], {"target": target, "result": result}
 
     def _do_work_sync(self, target: str) -> bool:
-        """Blocking work. Called via run_in_executor — no await here."""
+        """Blocking work. Called via run_in_executor - no await here."""
         return True
 ```
 
@@ -199,7 +198,7 @@ class MyModule(BaseModule):
 | Pattern | Rule |
 |---------|------|
 | Blocking I/O | Always `loop.run_in_executor(None, self._sync_fn)` |
-| Connection cleanup | `conn = None` → `try:` → `finally: if conn: conn.close()` |
+| Connection cleanup | `conn = None` -> `try:` -> `finally: if conn: conn.close()` |
 | Pagination | `while cookie:` loop with `1.2.840.113556.1.4.319` OID for LDAP |
 | STEALTH block | HIGH_NOISE modules must raise `ModuleValidationError` in STEALTH |
 | dry_run | Always check `ctx.dry_run` first in `execute()` |
@@ -250,20 +249,20 @@ pytest tests/unit/ --cov=ares --cov-fail-under=82 -v  # with coverage
 1. All pre-commit hooks pass (`pre-commit run --all-files`)
 2. Tests pass with `pytest tests/unit/ --cov=ares --cov-fail-under=82`
 3. PR description includes: what changed, why, MITRE reference (for modules)
-4. Update `CHANGELOG.md` — add entry under `[Unreleased]` section
-5. At least one maintainer review required before merge to `develop`
-6. Squash merge to `develop` — no merge commits
+4. Update `CHANGELOG.md` - add entry under `[Unreleased]` section
+5. At least one maintainer review required before merge to `main`
+6. Squash merge to `main`; no merge commits
 
 ---
 
 ## Code Standards
 
-- **Python 3.10+** — use `match`, `|` union types, `TypeAlias` where appropriate
+- **Python 3.10+** - use `match`, `|` union types, `TypeAlias` where appropriate
 - **Pydantic v2** for all settings and data models
-- **structlog** for all logging — never `print()` or stdlib `logging` directly
-- **asyncio** throughout — no blocking calls on the event loop
-- **type annotations** on all public functions — mypy strict enabled
+- **structlog** for all logging - never `print()` or stdlib `logging` directly
+- **asyncio** throughout - no blocking calls on the event loop
+- **type annotations** on all public functions - mypy strict enabled
 - **ruff** for linting (replaces flake8, isort, pyupgrade)
-- **No hardcoded secrets** — everything via `.env` or env vars
+- **No hardcoded secrets** - everything via `.env` or env vars
 
 Questions? Open an issue or ping `@ares-framework/maintainers` on GitHub.

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -30,7 +30,8 @@ python -m pip install -e ".[dev,pdf]"
 
 Notes:
 
-- The setup script installs the local project in editable mode.
+- The setup script is the Linux/macOS bootstrap path. On Windows, use the
+  PowerShell commands above to create `.venv` and install the editable package.
 - Some offensive-security integrations are optional. `ares doctor` will tell you which optional packages or native tools are missing for AD, cloud, container, or password-cracking workflows.
 - PDF support uses WeasyPrint when available and has a local browser fallback in the API.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ and professional report generation.
 [![FastAPI](https://img.shields.io/badge/API-FastAPI-009688?style=for-the-badge&logo=fastapi&logoColor=white)](https://fastapi.tiangolo.com)
 [![React](https://img.shields.io/badge/Dashboard-React-61DAFB?style=for-the-badge&logo=react&logoColor=111111)](https://react.dev)
 [![License](https://img.shields.io/badge/License-MIT-22C55E?style=for-the-badge)](LICENSE)
-[![Status](https://img.shields.io/badge/Unit%20Suite-1102%20passing-22C55E?style=for-the-badge)](tests/)
+[![Status](https://img.shields.io/badge/Unit%20Suite-passing-22C55E?style=for-the-badge)](tests/)
 
 **Built for labs, internal security teams, and authorized engagements only.**
 
@@ -563,7 +563,7 @@ See [docs/architecture.md](docs/architecture.md) and
 Current local verification:
 
 ```text
-1102 unit tests passed
+unit suite passed
 frontend build passed
 validation lab passed
 ares doctor dependency display and local-env isolation covered by tests

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,9 +4,9 @@
 
 | Version | Supported |
 |---------|-----------|
-| 6.x     | ✅ Active security fixes |
-| 5.x     | ❌ End of life — upgrade to v6 |
-| < 5.0   | ❌ End of life |
+| 6.x     |  Active security fixes |
+| 5.x     |  End of life - upgrade to v6 |
+| < 5.0   |  End of life |
 
 ---
 
@@ -24,8 +24,9 @@ Include in your report:
 - Potential impact assessment
 - Any suggested mitigations (optional)
 
-PGP key: Generate and publish your PGP key before making this repository public.
-Upload to a public keyserver (keys.openpgp.org) and link it here.
+PGP: No project PGP key is currently published. Email first if encrypted
+coordination is required, and do not include sensitive exploit details until an
+encrypted channel has been agreed.
 
 ### Response timeline
 
@@ -44,14 +45,14 @@ We follow [coordinated vulnerability disclosure](https://vuls.cert.org/confluenc
 
 ### In scope
 - Authentication bypass in the ARES API (`ares/api/`)
-- Credential exposure — vault encryption, log redaction failures
-- RBAC bypass — escalating from `reporter` to `operator` or `team_lead`
+- Credential exposure - vault encryption, log redaction failures
+- RBAC bypass - escalating from `reporter` to `operator` or `team_lead`
 - SQL injection or command injection in any module input handling
-- Scope guard bypass — running modules against out-of-scope targets
+- Scope guard bypass - running modules against out-of-scope targets
 - Dependency vulnerabilities with direct exploitability in ARES context
 
 ### Out of scope
-- Issues in modules that require compromising the target first (by design — ARES is a red team tool)
+- Issues in modules that require compromising the target first (by design - ARES is a red team tool)
 - Denial of service against the ARES API
 - Issues in `[dev]` optional dependencies
 - Social engineering
@@ -60,25 +61,25 @@ We follow [coordinated vulnerability disclosure](https://vuls.cert.org/confluenc
 
 ## Security Design
 
-### API Response Data — Intentional Sensitive Output
+### API Response Data - Intentional Sensitive Output
 
 `EngineModuleResult.raw_output` in API responses intentionally contains
 captured hashes, Kerberos tickets, and credentials. This is the core value
-of a red team tool — the operator needs this data to continue the engagement.
+of a red team tool - the operator needs this data to continue the engagement.
 
 Protections applied to this data:
 
 | Protection | Implementation |
 |-----------|----------------|
-| Authentication | `require_operator()` — only authenticated operators can run modules |
-| Authorization | RBAC — `reporter` and `recon` roles cannot run credential modules |
+| Authentication | `require_operator()` - only authenticated operators can run modules |
+| Authorization | RBAC - `reporter` and `recon` roles cannot run credential modules |
 | Transport | HTTPS enforced via nginx TLS + HSTS |
 | Caching | `Cache-Control: no-store` on all API responses |
 | Rate limiting | Per-endpoint limits prevent bulk extraction |
 | Audit log | Every `module_run_start` and `module_run_complete` is logged with actor |
 
 Operators should treat ARES API responses with the same sensitivity as
-the data they contain — store engagement results in encrypted storage.
+the data they contain - store engagement results in encrypted storage.
 
 ## Security Design
 
@@ -89,7 +90,7 @@ Key security controls in ARES v6:
 | Credential encryption | Fernet with per-record PBKDF2-SHA256 salt (100,000 iterations) |
 | Legacy encryption | Configurable via `ARES_LEGACY_SALT` env var |
 | JWT tokens | HS256 default; RS256 supported via `ARES_JWT_ALGORITHM=RS256` |
-| Token revocation | JTI blacklist — logout immediately invalidates tokens |
+| Token revocation | JTI blacklist - logout immediately invalidates tokens |
 | Scope enforcement | `ScopeGuard` hard-stops all modules; fails closed |
 | Log redaction | Hashes, passwords, JWTs stripped from all structlog output |
 | STEALTH enforcement | HIGH_NOISE modules raise `ModuleValidationError` before any network call |

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1,8 +1,8 @@
-# ARES v6.0.0 — Minimum-version dependency reference
+# ARES v6.0.0 - Minimum-version dependency reference
 # Generated from: pyproject.toml declared dependencies (core + full extras)
 #
 # WARNING: This file uses >= ranges, NOT pinned == versions.
-# It does NOT guarantee reproducible installs — two installs at different
+# It does NOT guarantee reproducible installs - two installs at different
 # times may get different versions of transitive dependencies.
 #
 # For a true reproducible lock file, run in a clean environment:
@@ -19,7 +19,7 @@
 # Install from this file:
 #   pip install -r requirements-lock.txt
 #
-# ── Core ──────────────────────────────────────────────────────────────────────
+# Core
 click>=8.1
 rich>=13.7
 pydantic>=2.6
@@ -29,7 +29,7 @@ python-dotenv>=1.0
 anyio>=4.3
 structlog>=24.1
 
-# ── API + Auth ─────────────────────────────────────────────────────────────────
+# API + Auth
 fastapi>=0.110
 uvicorn[standard]>=0.27
 PyJWT[crypto]>=2.8
@@ -37,41 +37,41 @@ bcrypt>=4.0
 python-multipart>=0.0.9
 websockets>=12.0
 
-# ── HTTP client ────────────────────────────────────────────────────────────────
+# HTTP client
 httpx>=0.27
 
-# ── Crypto ────────────────────────────────────────────────────────────────────
+# Crypto
 cryptography>=42.0
 
-# ── Database ──────────────────────────────────────────────────────────────────
+# Database
 aiosqlite>=0.20
 sqlalchemy>=2.0
 aiofiles>=23.2
 
-# ── Graph ─────────────────────────────────────────────────────────────────────
+# Graph
 networkx>=3.3
 
-# ── Reporting ─────────────────────────────────────────────────────────────────
+# Reporting
 jinja2>=3.1
 markdown>=3.5
 
-# ── CLI ───────────────────────────────────────────────────────────────────────
+# CLI
 typer>=0.12
 
-# ── Network / DNS ─────────────────────────────────────────────────────────────
+# Network / DNS
 dnspython>=2.6
 netaddr>=1.2
 
-# ── SSH lateral movement ──────────────────────────────────────────────────────
+# SSH lateral movement
 paramiko>=3.4
 
-# ── [ad] extra — Active Directory + SMB ──────────────────────────────────────
+# [ad] extra - Active Directory + SMB
 impacket>=0.11
 ldap3>=2.9
 pywinrm>=0.4
 asyncssh>=2.14
 
-# ── [cloud] extra ─────────────────────────────────────────────────────────────
+# [cloud] extra
 boto3>=1.34
 botocore>=1.34
 azure-identity>=1.15
@@ -81,18 +81,18 @@ azure-mgmt-network>=25.0
 google-cloud-resource-manager>=1.12
 google-cloud-iam>=2.13
 
-# ── [container] extra ─────────────────────────────────────────────────────────
+# [container] extra
 docker>=7.0
 kubernetes>=29.0
 
-# ── [pdf] extra ───────────────────────────────────────────────────────────────
+# [pdf] extra
 weasyprint>=62.0
 
-# ── [postgres] extra (optional) ───────────────────────────────────────────────
+# [postgres] extra (optional)
 # Uncomment if using PostgreSQL backend:
 # asyncpg>=0.29
 
-# ── [dev] extra — not needed in production ────────────────────────────────────
+# [dev] extra - not needed in production
 # pytest>=8.0
 # pytest-asyncio>=0.23
 # pytest-cov>=5.0


### PR DESCRIPTION
## Summary

This PR cleans root-level docs/config hygiene after the recent code and SDK fixes.

Changes:
- Normalized non-portable Unicode separators/em dashes in root docs/config comments.
- Removed stale hardcoded README unit-test count.
- Updated stale `develop` branch workflow wording to short-lived branches from `main`.
- Clarified Windows vs Linux/macOS setup guidance.
- Replaced placeholder SECURITY PGP wording with realistic encrypted-coordination guidance.
- Cleaned comment/header formatting in requirements/pre-commit/gitignore without changing dependency versions or hook behavior.

## Validation

Passed locally:

```text
bash -n scripts/setup.sh
passed

python -m compileall ares tests
passed

pytest tests/unit/test_sdk_public_api.py -q --tb=short --timeout=60 --timeout-method=thread
5 passed

git diff --check
passed; only Git LF-to-CRLF working-copy warnings

Full unit suite was attempted locally on the office Windows machine with Python 3.13.14, but was blocked by a Hypothesis deadline timing failure unrelated to this docs/config-only patch:

tests/unit/test_sanitizers_property.py::TestCrossSanitizerProperties::test_hostname_then_path_no_crash
DeadlineExceeded: value='COM1' took ~330ms, exceeding the 200ms Hypothesis deadline
```