### PR TITLE
fix: fail fast on browser PDF generation timeout

### DIFF
--- a/ares/modules/reporting/report_gen.py
+++ b/ares/modules/reporting/report_gen.py
@@ -58,6 +58,8 @@ REMEDIATION_SLA = {
     "info": 365,
 }
 
+BROWSER_PDF_TIMEOUT_SECONDS = 15
+
 
 # ── Context builder ───────────────────────────────────────────────────────────
 
@@ -1876,8 +1878,16 @@ class ReportGenerator:
                         capture_output=True,
                         check=False,
                         text=True,
-                        timeout=60,
+                        timeout=BROWSER_PDF_TIMEOUT_SECONDS,
                     )
+                except subprocess.TimeoutExpired as exc:
+                    logger.warning(
+                        "pdf_browser_failed",
+                        browser=str(browser),
+                        error=str(exc),
+                        timeout_s=BROWSER_PDF_TIMEOUT_SECONDS,
+                    )
+                    continue
                 except (OSError, subprocess.SubprocessError) as exc:
                     logger.warning(
                         "pdf_browser_failed", browser=str(browser), error=str(exc)

--- a/tests/unit/db/test_database.py
+++ b/tests/unit/db/test_database.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import subprocess
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -19,7 +20,10 @@ from ares.core.engine import AresEngine, ExecutionPlan, ModuleStatus
 from ares.core.plugin.loader import ModuleRegistry, PluginLoader
 from ares.db.database import AresDatabase, Credential, Host, Loot
 from ares.modules.base import BaseModule
-from ares.modules.reporting.report_gen import ReportGenerator
+from ares.modules.reporting.report_gen import (
+    BROWSER_PDF_TIMEOUT_SECONDS,
+    ReportGenerator,
+)
 
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
@@ -277,6 +281,26 @@ class TestReportGenerator:
         assert "markdown" in paths
         for p in paths.values():
             assert p.exists()
+
+    def test_pdf_browser_timeout_returns_false(self, tmp_path: Path) -> None:
+        gen = ReportGenerator(output_dir=str(tmp_path))
+        browser = tmp_path / "chromium"
+        browser.write_text("", encoding="utf-8")
+        pdf_path = tmp_path / "report.pdf"
+
+        with (
+            patch.object(gen, "_pdf_browser_candidates", return_value=[browser]),
+            patch(
+                "ares.modules.reporting.report_gen.subprocess.run",
+                side_effect=subprocess.TimeoutExpired(
+                    cmd=[str(browser)], timeout=BROWSER_PDF_TIMEOUT_SECONDS
+                ),
+            ) as run_browser,
+        ):
+            assert gen._write_pdf_with_browser("<html></html>", pdf_path) is False
+
+        assert run_browser.call_args.kwargs["timeout"] == BROWSER_PDF_TIMEOUT_SECONDS
+        assert not pdf_path.exists()
 
     def test_json_structure_valid(self, campaign_with_findings: Campaign, tmp_path: Path) -> None:
         gen = ReportGenerator(output_dir=str(tmp_path))


### PR DESCRIPTION
## Summary
- Add a shorter browser PDF generation timeout.
- Catch browser PDF timeout and return `False` instead of letting the unit suite hang.
- Preserve graceful report generation fallback when WeasyPrint/browser PDF generation is unavailable.
- Add regression coverage for browser timeout handling.

## Validation
- `python -m compileall ares tests` passed.
- `python -m pytest tests/unit/db/test_database.py::TestReportGenerator::test_generate_all -q --tb=short --timeout=60 --timeout-method=thread` passed.
- `python -m pytest tests/unit/db/test_database.py -q --tb=short --timeout=60 --timeout-method=thread --maxfail=1` passed: 21 passed.
- `git diff --check` clean.