### PR TITLE
fix: preserve Windows temp artifact access during ACL hardening

### DIFF
--- a/ares/core/security.py
+++ b/ares/core/security.py
@@ -402,26 +402,115 @@ _ARTIFACT_LOCK = threading.Lock()
 _GLOBAL_SCOPE = "_GLOBAL"
 
 
-def _restrict_windows_acl(path: str, *, is_dir: bool = False) -> None:
-    """Best-effort owner-only ACL restriction for Windows temp artifacts."""
+def _restrict_windows_acl(
+    path: str,
+    *,
+    is_dir: bool = False,
+    require_success: bool = False,
+) -> bool:
+    """Best-effort owner-only ACL restriction for Windows temp artifacts.
+
+    Returns True when the ACL was hardened. If hardening fails, the default is
+    to preserve a usable temp artifact and log the failure; callers that need
+    fail-closed behavior can pass require_success=True.
+    """
+    import csv
     import getpass
     import os
     import subprocess
 
     if os.name != "nt":
-        return
+        return True
 
-    user = os.environ.get("USERNAME") or getpass.getuser()
-    grant = f"{user}:{'(OI)(CI)F' if is_dir else 'F'}"
-    try:
-        subprocess.run(
-            ["icacls", path, "/inheritance:r", "/grant:r", grant],
+    def _run_icacls(args: list[str]) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["icacls", path, *args],
             capture_output=True,
             check=False,
             text=True,
+            timeout=10,
         )
-    except OSError as exc:
-        logger.debug("credential_artifact_acl_restrict_failed", path=path, error=str(exc))
+
+    def _current_principal() -> str:
+        try:
+            completed = subprocess.run(
+                ["whoami", "/user", "/fo", "csv", "/nh"],
+                capture_output=True,
+                check=False,
+                text=True,
+                timeout=10,
+            )
+            if completed.returncode == 0 and completed.stdout.strip():
+                rows = list(csv.reader(completed.stdout.splitlines()))
+                if rows and len(rows[0]) >= 2 and rows[0][1].strip():
+                    return f"*{rows[0][1].strip()}"
+        except (OSError, subprocess.SubprocessError):
+            pass
+
+        username = os.environ.get("USERNAME") or getpass.getuser()
+        domain = os.environ.get("USERDOMAIN", "").strip()
+        return f"{domain}\\{username}" if domain and username else username
+
+    def _warn(event: str, completed: subprocess.CompletedProcess[str] | None = None) -> None:
+        logger.warning(
+            event,
+            path=path,
+            returncode=getattr(completed, "returncode", None),
+            stdout=(getattr(completed, "stdout", "") or "")[:300],
+            stderr=(getattr(completed, "stderr", "") or "")[:300],
+        )
+
+    def _fail(event: str, completed: subprocess.CompletedProcess[str] | None = None) -> bool:
+        _warn(event, completed)
+        if require_success:
+            raise PermissionError(f"{event}: unable to harden ACL for {path!r}")
+        return False
+
+    principal = _current_principal()
+    grant = f"{principal}:{'(OI)(CI)F' if is_dir else 'F'}"
+    try:
+        grant_result = _run_icacls(["/grant:r", grant])
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.warning("credential_artifact_acl_grant_failed", path=path, error=str(exc))
+        if require_success:
+            raise PermissionError(f"unable to grant owner ACL for {path!r}") from exc
+        return False
+    if grant_result.returncode != 0:
+        return _fail("credential_artifact_acl_grant_failed", grant_result)
+
+    try:
+        inherit_result = _run_icacls(["/inheritance:r"])
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.warning("credential_artifact_acl_inheritance_failed", path=path, error=str(exc))
+        try:
+            _run_icacls(["/inheritance:e"])
+            _run_icacls(["/grant:r", grant])
+        except (OSError, subprocess.SubprocessError) as restore_exc:
+            logger.warning(
+                "credential_artifact_acl_restore_failed",
+                path=path,
+                error=str(restore_exc),
+            )
+        if require_success:
+            raise PermissionError(f"unable to remove inherited ACL for {path!r}") from exc
+        return False
+    if inherit_result.returncode != 0:
+        try:
+            restore_result = _run_icacls(["/inheritance:e"])
+            if restore_result.returncode != 0:
+                _warn("credential_artifact_acl_restore_failed", restore_result)
+            restore_grant_result = _run_icacls(["/grant:r", grant])
+            if restore_grant_result.returncode != 0:
+                _warn("credential_artifact_acl_restore_failed", restore_grant_result)
+        except (OSError, subprocess.SubprocessError) as restore_exc:
+            logger.warning(
+                "credential_artifact_acl_restore_failed",
+                path=path,
+                error=str(restore_exc),
+            )
+        return _fail("credential_artifact_acl_inheritance_failed", inherit_result)
+
+    return True
 
 
 def secure_mkstemp(

--- a/tests/unit/test_final_hardening.py
+++ b/tests/unit/test_final_hardening.py
@@ -124,6 +124,21 @@ class TestCleanupGuarantee:
         with _ARTIFACT_LOCK:
             _CREDENTIAL_ARTIFACTS.clear()
 
+    def test_secure_mkstemp_reopenable_after_close(self):
+        """Windows ACL hardening must not make the temp file unusable."""
+        from ares.core.security import secure_mkstemp, cleanup_credential_artifacts
+        self._reset_tracking()
+
+        p, fd = secure_mkstemp(suffix=".ccache", campaign_id="reopen-test")
+        os.close(fd)
+        try:
+            with open(p, "w", encoding="utf-8") as f:
+                f.write("ticket data")
+            with open(p, encoding="utf-8") as f:
+                assert f.read() == "ticket data"
+        finally:
+            cleanup_credential_artifacts("reopen-test")
+
     def test_cleanup_always_runs_on_success(self):
         """Cleanup works after successful operation."""
         from ares.core.security import secure_mkstemp, cleanup_credential_artifacts


### PR DESCRIPTION
## Summary
- Make Windows ACL hardening transactional for secure credential temp artifacts.
- Grant the current Windows principal before removing inheritance.
- Check `icacls` return codes and use finite subprocess timeouts.
- Restore usable ACL state on inheritance-removal failure.
- Preserve usable temp behavior by default while keeping `require_success=True` fail-closed.
- Add regression coverage proving `secure_mkstemp()` output can be reopened after `os.close(fd)`.

## Validation
- `python -m compileall ares tests` passed.
- `python -m pytest tests/unit/test_final_hardening.py::TestCleanupGuarantee::test_cleanup_always_runs_on_success -q --tb=short --timeout=60 --timeout-method=thread` passed.
- `python -m pytest tests/unit/test_final_hardening.py -q --tb=short --timeout=60 --timeout-method=thread --maxfail=1` passed: 16 passed.
- `git diff --check` clean.

## Notes
Full local Windows unit gate remains blocked by unrelated Hypothesis deadline timing flakes in `tests/unit/test_property_based.py`, outside this patch scope.