### PR TITLE
fix: honor module timeout during retry execution

### DIFF
--- a/ares/core/engine.py
+++ b/ares/core/engine.py
@@ -221,6 +221,15 @@ class AresEngine:
         cls      = self.registry.get(module_id)
         noise    = NoiseController(campaign)
         instance = cls(settings=self.settings, campaign=campaign, noise=noise)  # type: ignore[misc]
+        # Respect per-module timeout if declared (MODULE_TIMEOUT_SECONDS)
+        module_timeout = getattr(instance.__class__, "MODULE_TIMEOUT_SECONDS", None)
+        effective_timeout = (
+            module_timeout if module_timeout is not None else timeout_seconds
+        )
+        if effective_timeout != timeout_seconds:
+            logger.debug("engine_using_module_timeout",
+                         module_id=module_id,
+                         timeout=effective_timeout)
 
         audit("module_run_start", actor=campaign.operator,
               detail=f"module={module_id} campaign={campaign.id[:8]}")
@@ -279,23 +288,20 @@ class AresEngine:
             # Falls back to run(**ctx.params) via BaseModule.execute() default
             # for modules that haven't migrated yet.
             execute_coro = instance.execute(ctx)
-            # Respect per-module timeout if declared (MODULE_TIMEOUT_SECONDS)
-            effective_timeout = (
-                getattr(instance.__class__, "MODULE_TIMEOUT_SECONDS", None)
-                or timeout_seconds
-            )
-            if effective_timeout != timeout_seconds:
-                logger.debug("engine_using_module_timeout",
-                             module_id=module_id,
-                             timeout=effective_timeout)
             module_result = await asyncio.wait_for(
                 execute_coro, timeout=effective_timeout
             )
             findings = module_result.findings
             raw      = module_result.raw
         except asyncio.TimeoutError:
-            logger.error("engine_timed_out_s", module_id=module_id, timeout_seconds=timeout_seconds)
-            _last_exc: Exception = asyncio.TimeoutError(f"Timed out after {timeout_seconds}s")
+            logger.error(
+                "engine_timed_out_s",
+                module_id=module_id,
+                timeout_seconds=effective_timeout,
+            )
+            _last_exc: Exception = asyncio.TimeoutError(
+                f"Timed out after {effective_timeout}s"
+            )
             _action = AresError.RETRY
         except AresError as exc:
             logger.warning("engine_areserror", module_id=module_id, action=exc.action, exc=exc)
@@ -339,7 +345,7 @@ class AresEngine:
                         noise      = noise,
                     )
                     module_result2 = await asyncio.wait_for(
-                        module2.execute(ctx2), timeout=timeout_seconds
+                        module2.execute(ctx2), timeout=effective_timeout
                     )
                     findings = module_result2.findings
                     raw      = module_result2.raw
@@ -348,7 +354,12 @@ class AresEngine:
                 except asyncio.TimeoutError as te:
                     _last_exc = te
                     _was_timeout = True
-                    logger.warning("engine_retry_timed_out", module_id=module_id, attempt=attempt)
+                    logger.warning(
+                        "engine_retry_timed_out",
+                        module_id=module_id,
+                        attempt=attempt,
+                        timeout_seconds=effective_timeout,
+                    )
                 except Exception as re:
                     _last_exc = re
                     logger.warning("engine_retry_failed", module_id=module_id, attempt=attempt, re=re)

--- a/tests/unit/test_sdk_public_api.py
+++ b/tests/unit/test_sdk_public_api.py
@@ -166,6 +166,64 @@ async def test_runtime_uses_module_timeout_contract(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_runtime_retries_use_module_timeout_contract(monkeypatch) -> None:
+    @sdk.module_metadata(
+        module_id="demo.retry_timeout",
+        name="Demo Retry Timeout",
+        category="network",
+        description="Runtime retry timeout contract test",
+    )
+    @sdk.timeout(7)
+    class DemoModule(sdk.BaseModule):
+        execute_calls = 0
+
+        async def execute(self, ctx: sdk.ExecutionContext) -> sdk.ModuleResult:
+            type(self).execute_calls += 1
+            if type(self).execute_calls == 1:
+                raise asyncio.TimeoutError
+            return sdk.ModuleResult(status="success", module_id=self.MODULE_ID)
+
+        async def run(self, **kwargs):
+            return [], {"ok": True}
+
+    observed_timeouts: list[int | float | None] = []
+    original_wait_for = asyncio.wait_for
+
+    async def capture_wait_for(awaitable, timeout=None):
+        observed_timeouts.append(timeout)
+        return await original_wait_for(awaitable, timeout)
+
+    async def no_sleep(_delay):
+        return None
+
+    class Registry:
+        def __contains__(self, module_id):
+            return module_id == "demo.retry_timeout"
+
+        def get(self, module_id):
+            assert module_id == "demo.retry_timeout"
+            return DemoModule
+
+    monkeypatch.setattr(asyncio, "wait_for", capture_wait_for)
+    monkeypatch.setattr(asyncio, "sleep", no_sleep)
+    engine = AresEngine()
+    engine._registry = Registry()
+    helper = sdk.ModuleTestHelper(DemoModule, scope_cidrs=["127.0.0.1/32"])
+
+    result = await engine.run_module(
+        "demo.retry_timeout",
+        campaign=helper.campaign,
+        params={"target": "127.0.0.1"},
+        timeout_seconds=120,
+        actor_role="team_lead",
+    )
+
+    assert result.status.value == "done"
+    assert result.error is None
+    assert observed_timeouts == [10, 7, 7]
+
+
+@pytest.mark.asyncio
 async def test_module_test_helper_available_from_public_sdk() -> None:
     @sdk.module_metadata(
         module_id="demo.helper",


### PR DESCRIPTION
## Summary
- Compute one effective module timeout in `AresEngine.run_module`.
- Prefer `MODULE_TIMEOUT_SECONDS` when declared by the module.
- Reuse the effective timeout for initial execution, retry execution, timeout logging, and timeout error text.
- Preserve generic `timeout_seconds` behavior for modules without a module-specific timeout.
- Add regression coverage proving retry execution honors the SDK timeout contract.

## Validation
- `python -m compileall ares tests` passed.
- `python -m pytest tests/unit/test_engine.py -q --tb=short --timeout=60 --timeout-method=thread --maxfail=1` passed: 7 passed.
- `python -m pytest tests/unit/test_sdk_public_api.py -q --tb=short --timeout=60 --timeout-method=thread` passed: 20 passed.
- `python -m pytest tests/unit -q --tb=short --timeout=60 --timeout-method=thread --maxfail=1` passed: 1121 passed.
- `git diff --check` clean.