### PR TITLE
fix: enforce plugin loader path containment

### DIFF
--- a/ares/core/plugin/loader.py
+++ b/ares/core/plugin/loader.py
@@ -65,6 +65,10 @@ def _get_signing_policy():
         return None
 
 
+def _is_path_within_base(path: Path, base: Path) -> bool:
+    return path == base or path.is_relative_to(base)
+
+
 def _enforce_capabilities(cls: Any, source: str) -> list[str]:
     """
     Check a module's declared CAPABILITIES against its trust level.
@@ -309,7 +313,9 @@ class PluginLoader:
             Path.home().resolve(),
             Path("/tmp").resolve(),  # noqa: S108  — sandbox staging area
         ]
-        if not any(str(plugin_dir).startswith(str(base)) for base in _allowed_bases):
+        if not any(
+            _is_path_within_base(plugin_dir, base) for base in _allowed_bases
+        ):
             logger.error(
                 f"[plugin_loader] Rejected plugin dir outside allowed locations: {plugin_dir}. "
                 f"Must be under home directory or /tmp."

--- a/tests/unit/db/test_database.py
+++ b/tests/unit/db/test_database.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+import ares.core.plugin.loader as plugin_loader_module
 from ares.core.campaign import Campaign, Finding, NoiseProfile, Severity, ScopeEntry
 from ares.core.config import AresSettings
 from ares.core.engine import AresEngine, ExecutionPlan, ModuleStatus
@@ -96,6 +97,22 @@ class TestPluginLoader:
         loader = PluginLoader()
         loader._load_external(str(tmp_path))  # Should not raise
         assert loader.errors == []
+
+    def test_external_dir_containment_rejects_same_prefix_sibling(
+        self, tmp_path: Path
+    ) -> None:
+        allowed_base = (tmp_path / "plugins").resolve()
+        child_dir = (allowed_base / "child").resolve()
+        sibling_dir = (tmp_path / "plugins_evil").resolve()
+
+        child_dir.mkdir(parents=True)
+        sibling_dir.mkdir()
+
+        assert plugin_loader_module._is_path_within_base(allowed_base, allowed_base)
+        assert plugin_loader_module._is_path_within_base(child_dir, allowed_base)
+        assert not plugin_loader_module._is_path_within_base(
+            sibling_dir, allowed_base
+        )
 
     def test_external_plugin_loaded(self, tmp_path: Path) -> None:
         """Write a valid external plugin and verify it's discovered."""


### PR DESCRIPTION
## Summary
- Replace string-prefix external plugin directory containment with robust `Path` containment.
- Allow only the exact allowed base or true child paths.
- Reject same-prefix sibling directories such as `plugins_evil`.
- Preserve existing valid external plugin loading behavior.
- Add focused regression coverage for plugin path containment.

## Validation
- `python -m compileall ares tests` passed.
- Focused plugin loader tests passed: 8 passed.
- `python -m pytest tests/unit -q --tb=short --timeout=60 --timeout-method=thread --maxfail=1` passed: 1122 passed.
- `git diff --check` clean.