### PR TITLE
docs: align requirements reference with declared extras

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -47,6 +47,7 @@ cryptography>=42.0
 aiosqlite>=0.20
 sqlalchemy>=2.0
 aiofiles>=23.2
+alembic>=1.13
 
 # Graph
 networkx>=3.3
@@ -70,6 +71,7 @@ impacket>=0.11
 ldap3>=2.9
 pywinrm>=0.4
 asyncssh>=2.14
+httpx-ntlm>=1.4
 
 # [cloud] extra
 boto3>=1.34
@@ -80,10 +82,14 @@ azure-mgmt-compute>=30.0
 azure-mgmt-network>=25.0
 google-cloud-resource-manager>=1.12
 google-cloud-iam>=2.13
+msal>=1.28
 
 # [container] extra
 docker>=7.0
 kubernetes>=29.0
+
+# [windows] extra
+pypykatz>=0.6
 
 # [pdf] extra
 weasyprint>=62.0
@@ -94,6 +100,7 @@ weasyprint>=62.0
 
 # [dev] extra - not needed in production
 # pytest>=8.0
+# hypothesis>=6.100
 # pytest-asyncio>=0.23
 # pytest-cov>=5.0
 # pytest-mock>=3.14


### PR DESCRIPTION
## Summary
- Align `requirements-lock.txt` with dependencies declared in `pyproject.toml`.
- Add missing declared references for core and extras:
  - `alembic>=1.13`
  - `httpx-ntlm>=1.4`
  - `msal>=1.28`
  - `pypykatz>=0.6`
  - `# hypothesis>=6.100`
- Preserve the file as a minimum-version reference, not a pinned reproducible lock file.
- No runtime code changed.

## Validation
- `python -m compileall ares tests` passed.
- `python -m pytest tests/unit -q --tb=short --timeout=60 --timeout-method=thread --maxfail=1` passed: 1122 passed.
- `git diff --check` clean.