### PR TITLE
fix: strip ldap injection metacharacters

### DIFF
--- a/ares/core/security.py
+++ b/ares/core/security.py
@@ -261,25 +261,19 @@ class DataEncryptor:
 
 # ── Input sanitization ────────────────────────────────────────────────────────
 
-_LDAP_INJECTION_CHARS = re.compile(r"[\\*()\x00]")
+_LDAP_INJECTION_CHARS = re.compile(r"[\\*()\x00-\x1f\x7f]")
 _COMMAND_INJECTION_CHARS = re.compile(r"[;&|`$<>]")
 _PATH_TRAVERSAL = re.compile(r"\.\./|\.\.\\")
 
 
 def sanitize_ldap(value: str) -> str:
-    """Escape LDAP special chars per RFC 4515 to prevent injection."""
-    try:
-        from ldap3.utils.conv import escape_filter_chars  # type: ignore[import]
-
-        return escape_filter_chars(value)
-    except ImportError:
-        # Fallback if ldap3 not installed — strip dangerous chars
-        sanitized = _LDAP_INJECTION_CHARS.sub("", value)
-        if sanitized != value:
-            logger.warning(
-                "security_ldap_injection_chars_stripped_from", value=repr(value)
-            )
-        return sanitized
+    """Strip LDAP injection metacharacters from user-controlled input."""
+    sanitized = _LDAP_INJECTION_CHARS.sub("", value)
+    if sanitized != value:
+        logger.warning(
+            "security_ldap_injection_chars_stripped_from", value=repr(value)
+        )
+    return sanitized
 
 
 def sanitize_hostname(value: str) -> str:

--- a/tests/unit/core/test_core.py
+++ b/tests/unit/core/test_core.py
@@ -132,6 +132,11 @@ class TestSecurity:
     def test_sanitize_ldap_strips_injection(self):
         assert sanitize_ldap("admin)(uid=*)") == "adminuid="
 
+    def test_sanitize_ldap_strips_metachars_and_preserves_safe_chars(self):
+        assert sanitize_ldap(r"user\name*(cn=admin)\x00") == r"usernamecn=adminx00"
+        assert sanitize_ldap("a\x00b\x1fc\x7fd") == "abcd"
+        assert sanitize_ldap("john.doe-user_1@example.com = ok") == "john.doe-user_1@example.com = ok"
+
     def test_sanitize_hostname_strips_special(self):
         assert sanitize_hostname("host; rm -rf /") == "hostrm-rf"
 


### PR DESCRIPTION
## Summary
- Align sanitize_ldap with the existing project contract.
- Strip LDAP injection metacharacters instead of returning RFC4515 escape sequences.
- Strip (, ), *, backslash, NUL, C0 controls, and DEL.
- Preserve normal safe characters.

## Validation
- python -m compileall ares tests
- pytest tests\unit\core\test_core.py::TestSecurity::test_sanitize_ldap_strips_injection -q --tb=short --timeout=60 --timeout-method=thread --maxfail=1
- pytest tests\unit\core\test_core.py -q --tb=short --timeout=60 --timeout-method=thread --maxfail=1
- pytest tests\unit -q --tb=short --timeout=60 --timeout-method=thread --maxfail=1

## Results
- focused sanitizer test: passed
- core test file: 23 passed
- full unit suite: 1127 passed, 94 warnings