### PR TITLE
fix: harden doctor and setup portability

### DIFF
--- a/ares/cli/typer_main.py
+++ b/ares/cli/typer_main.py
@@ -1071,14 +1071,21 @@ def doctor() -> None:
         nonlocal ok, warn, fail
         suffix = f"  [dim]{escape(str(detail))}[/dim]" if detail else ""
         if status == "ok":
-            console.print(f"  [green]✅[/green]  {label}" + suffix)
+            console.print(f"  [green][OK][/green]  {label}" + suffix)
             ok += 1
         elif status == "warn":
-            console.print(f"  [yellow]⚠️ [/yellow]  {label}" + suffix)
+            console.print(f"  [yellow][WARN][/yellow]  {label}" + suffix)
             warn += 1
         else:
-            console.print(f"  [red]❌[/red]  {label}" + suffix)
+            console.print(f"  [red][FAIL][/red]  {label}" + suffix)
             fail += 1
+
+    def import_failure_detail(import_name: str, exc: Exception, hint: str = "") -> str:
+        message = str(exc) or repr(exc)
+        detail = f"import {import_name} failed: {exc.__class__.__name__}: {message}"
+        if hint:
+            detail = f"{detail}; {hint}"
+        return detail
 
     # Python version
     import sys
@@ -1104,11 +1111,15 @@ def doctor() -> None:
             mod = importlib.import_module(import_name)
             ver = getattr(mod, "__version__", "")
             check(label, "ok", ver)
-        except ImportError:
+        except Exception as exc:
             if pkg in ("impacket", "paramiko"):
-                check(label, "fail", f"pip install ares-redteam[ad]")
+                check(
+                    label,
+                    "fail",
+                    import_failure_detail(import_name, exc, "pip install ares-redteam[ad]"),
+                )
             else:
-                check(label, "warn", f"pip install {pkg}")
+                check(label, "warn", import_failure_detail(import_name, exc, f"pip install {pkg}"))
 
     # ── impacket version ──────────────────────────────────────────────────────
     try:
@@ -1127,30 +1138,34 @@ def doctor() -> None:
         else:
             check("impacket", "warn",
                   "installed, but version could not be detected — expected >= 0.11")
-    except ImportError:
-        check("impacket", "fail", "pip install ares-redteam[ad]")
+    except Exception as exc:
+        check(
+            "impacket",
+            "fail",
+            import_failure_detail("impacket", exc, "pip install ares-redteam[ad]"),
+        )
 
     # ── ldap3 ─────────────────────────────────────────────────────────────────
     try:
         import ldap3
         check(f"ldap3 {ldap3.__version__}", "ok", "AD LDAP enumeration ready")
-    except ImportError:
-        check("ldap3", "warn", "pip install ares-redteam[ad]")
+    except Exception as exc:
+        check("ldap3", "warn", import_failure_detail("ldap3", exc, "pip install ares-redteam[ad]"))
 
     # ── optional Windows modules ───────────────────────────────────────────────
     try:
         import pypykatz  # type: ignore[import]
         check("pypykatz  (windows.lsass_dump)", "ok", "LSASS dump parsing ready")
-    except ImportError:
+    except Exception as exc:
         check("pypykatz  (windows.lsass_dump)", "warn",
-              "pip install ares-redteam[windows]")
+              import_failure_detail("pypykatz", exc, "pip install ares-redteam[windows]"))
 
     try:
         import httpx_ntlm  # type: ignore[import]
         check("httpx-ntlm  (ad.adcs ESC1)", "ok", "ADCS HTTP enrollment ready")
-    except ImportError:
+    except Exception as exc:
         check("httpx-ntlm  (ad.adcs ESC1)", "warn",
-              "pip install ares-redteam[ad]")
+              import_failure_detail("httpx_ntlm", exc, "pip install ares-redteam[ad]"))
 
     # ── cloud SDKs ────────────────────────────────────────────────────────────
     for import_name, module_label in [
@@ -1162,9 +1177,9 @@ def doctor() -> None:
         try:
             importlib.import_module(import_name)
             check(f"{import_name.split('.')[0]}  ({module_label})", "ok")
-        except ImportError:
+        except Exception as exc:
             check(f"{import_name.split('.')[0]}  ({module_label})", "warn",
-                  "pip install ares-redteam[cloud]")
+                  import_failure_detail(import_name, exc, "pip install ares-redteam[cloud]"))
 
     # ── cracking tools ────────────────────────────────────────────────────────
     for tool, desc in [("hashcat", "GPU cracking"), ("john", "CPU cracking")]:
@@ -1223,7 +1238,7 @@ def doctor() -> None:
                       " ARES should work — optional tools missing.\n")
     else:
         console.print(f"[bold red]{fail} check(s) failed.[/bold red]"
-                      f" Fix the ❌ items above, then re-run [cyan]ares doctor[/cyan].\n")
+                      f" Fix the [FAIL] items above, then re-run [cyan]ares doctor[/cyan].\n")
         raise typer.Exit(1)
 
 
@@ -1265,35 +1280,103 @@ def quickstart() -> None:
 
 # ── ares-setup entry point ────────────────────────────────────────────────────
 
-def setup_entrypoint() -> None:
-    """Entry point for `ares-setup` — runs setup.sh or inline setup."""
-    import subprocess, shutil, os
-    from pathlib import Path
+def _setup_platform_label(platform_name: str, os_name: str) -> str:
+    if os_name == "nt" or platform_name.startswith("win"):
+        return "Windows"
+    if platform_name == "darwin":
+        return "macOS"
+    if platform_name.startswith("linux"):
+        return "Linux"
+    return platform_name or os_name
 
-    setup_sh = Path(__file__).parent.parent.parent / "scripts" / "setup.sh"
-    if setup_sh.exists() and shutil.which("bash"):
-        os.execv(shutil.which("bash"), ["bash", str(setup_sh)])
+
+def _setup_fernet_key() -> str:
+    import base64
+    import secrets
+
+    return base64.urlsafe_b64encode(secrets.token_bytes(32)).decode("ascii")
+
+
+def _setup_admin_password(length: int = 20) -> str:
+    import secrets
+
+    alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$"
+    return "".join(secrets.choice(alphabet) for _ in range(length))
+
+
+def _upsert_env_value(template: str, key: str, value: str) -> str:
+    prefix = f"{key}="
+    lines = template.splitlines()
+    for index, line in enumerate(lines):
+        if line.startswith(prefix):
+            lines[index] = f"{prefix}{value}"
+            break
     else:
-        # Inline fallback for pip-installed package without scripts/
-        from cryptography.fernet import Fernet
-        import secrets
-        env = Path(".env")
-        if not env.exists():
-            ex = Path(".env.example")
-            template = ex.read_text() if ex.exists() else (
-                "ARES_SECRET_KEY=\nARES_ENCRYPTION_KEY=\nARES_DEFAULT_ADMIN_PASSWORD=\n"
-            )
-            sk  = secrets.token_hex(32)
-            ek  = Fernet.generate_key().decode()
-            pw  = ''.join(secrets.choice("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$") for _ in range(20))
-            import re
-            template = re.sub(r"ARES_SECRET_KEY=.*",             f"ARES_SECRET_KEY={sk}",  template)
-            template = re.sub(r"ARES_ENCRYPTION_KEY=.*",         f"ARES_ENCRYPTION_KEY={ek}", template)
-            template = re.sub(r"ARES_DEFAULT_ADMIN_PASSWORD=.*", f"ARES_DEFAULT_ADMIN_PASSWORD={pw}", template)
-            env.write_text(template)
-            print(f"\n✅ .env created\n   Admin password: {pw}\n   Run: ares doctor\n")
+        lines.append(f"{prefix}{value}")
+    return "\n".join(lines) + "\n"
+
+
+def _run_python_setup(
+    root: Path | None = None,
+    platform_name: str | None = None,
+    os_name: str | None = None,
+) -> None:
+    import os
+    import secrets
+
+    root_path = Path.cwd() if root is None else Path(root)
+    platform_value = sys.platform if platform_name is None else platform_name
+    os_value = os.name if os_name is None else os_name
+    platform_label = _setup_platform_label(platform_value, os_value)
+
+    console.print("\n[bold]ARES Setup[/bold]")
+    console.print(f"Platform: {platform_label} ({platform_value}/{os_value})")
+    console.print(f"Python: {sys.version.split()[0]} ({sys.executable})")
+
+    if sys.version_info < (3, 10):
+        console.print("[red]ERROR[/red] Python 3.10+ is required.")
+        raise SystemExit(1)
+
+    env_path = root_path / ".env"
+    example_path = root_path / ".env.example"
+
+    try:
+        if env_path.exists():
+            console.print("[green]OK[/green] .env already exists; leaving it unchanged.")
+            admin_password = None
         else:
-            print("✅ .env already exists. Run: ares doctor")
+            if example_path.exists():
+                template = example_path.read_text(encoding="utf-8")
+            else:
+                console.print("[yellow]Warning[/yellow] .env.example not found; using minimal template.")
+                template = "ARES_SECRET_KEY=\nARES_ENCRYPTION_KEY=\nARES_DEFAULT_ADMIN_PASSWORD=\n"
+
+            admin_password = _setup_admin_password()
+            template = _upsert_env_value(template, "ARES_SECRET_KEY", secrets.token_hex(32))
+            template = _upsert_env_value(template, "ARES_ENCRYPTION_KEY", _setup_fernet_key())
+            template = _upsert_env_value(template, "ARES_DEFAULT_ADMIN_PASSWORD", admin_password)
+            env_path.write_text(template, encoding="utf-8")
+            console.print(f"[green]OK[/green] .env created at {env_path}")
+            console.print(f"Admin password: {admin_password}")
+    except OSError as exc:
+        console.print(f"[red]ERROR[/red] setup failed: {exc.__class__.__name__}: {exc}")
+        raise SystemExit(1) from None
+
+    setup_sh = root_path / "scripts" / "setup.sh"
+    if setup_sh.exists() and (os_value == "nt" or platform_value.startswith("win")):
+        console.print("[yellow]Info[/yellow] scripts/setup.sh is POSIX-only and was skipped on Windows.")
+    elif setup_sh.exists():
+        console.print("[dim]Developer helper available: scripts/setup.sh (optional).[/dim]")
+
+    console.print("Next steps:")
+    console.print("  ares doctor")
+    if admin_password is not None:
+        console.print("  Store the generated admin password securely.")
+
+
+def setup_entrypoint() -> None:
+    """Entry point for `ares-setup` using Python-native cross-platform setup."""
+    _run_python_setup()
 
 
 # ── backup command ────────────────────────────────────────────────────────────

--- a/tests/unit/test_cli_doctor.py
+++ b/tests/unit/test_cli_doctor.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import importlib.metadata
+import os
 import sys
 import types
+
+import typer
 
 
 def test_doctor_uses_distribution_metadata_for_impacket(monkeypatch, tmp_path, capsys):
@@ -30,3 +33,98 @@ def test_doctor_uses_distribution_metadata_for_impacket(monkeypatch, tmp_path, c
     assert "impacket 0.13.1" in output
     assert "too old (0.0.0)" not in output
     assert "ares-redteam[ad]" in output
+
+
+def test_doctor_reports_broken_optional_import_and_continues(monkeypatch, tmp_path, capsys):
+    import importlib
+
+    from ares.cli.typer_main import doctor
+
+    real_import_module = importlib.import_module
+    fake_impacket = types.ModuleType("impacket")
+    fake_impacket.__version__ = "0.13.1"
+
+    def fake_version(package_name: str) -> str:
+        if package_name == "impacket":
+            return "0.13.1"
+        raise importlib.metadata.PackageNotFoundError(package_name)
+
+    def fake_import_module(import_name: str, package: str | None = None):
+        if import_name == "impacket":
+            raise OSError(22, "Invalid argument")
+        return real_import_module(import_name, package)
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".env").write_text("ARES_SECRET_KEY=test\n", encoding="utf-8")
+    monkeypatch.setitem(sys.modules, "impacket", fake_impacket)
+    monkeypatch.setattr(importlib.metadata, "version", fake_version)
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+
+    try:
+        doctor()
+    except typer.Exit:
+        pass
+
+    output = capsys.readouterr().out
+    assert "Traceback" not in output
+    assert "impacket" in output
+    assert "OSError" in output
+    assert "Invalid argument" in output
+    assert "paramiko" in output
+    assert "socket AF_INET/389" in output
+
+
+def test_setup_entrypoint_routes_to_python_native_setup(monkeypatch):
+    from ares.cli import typer_main
+
+    calls = []
+    monkeypatch.setattr(typer_main, "_run_python_setup", lambda: calls.append("called"))
+
+    typer_main.setup_entrypoint()
+
+    assert calls == ["called"]
+
+
+def test_python_setup_windows_skips_bash_and_uses_valid_paths(monkeypatch, tmp_path, capsys):
+    from ares.cli.typer_main import _run_python_setup
+
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / "scripts" / "setup.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    (tmp_path / ".env.example").write_text(
+        "ARES_SECRET_KEY=\nARES_ENCRYPTION_KEY=\nARES_DEFAULT_ADMIN_PASSWORD=\n",
+        encoding="utf-8",
+    )
+
+    def forbidden_execv(*args):
+        raise AssertionError("ares-setup must not exec bash")
+
+    monkeypatch.setattr(os, "execv", forbidden_execv)
+
+    _run_python_setup(root=tmp_path, platform_name="win32", os_name="nt")
+
+    output = capsys.readouterr().out
+    assert "ARES Setup" in output
+    assert "Windows" in output
+    assert "scripts/setup.sh is POSIX-only and was skipped on Windows" in output
+    assert "/bin/bash" not in output
+    assert "C:Users" not in output
+    assert (tmp_path / ".env").exists()
+
+
+def test_python_setup_posix_keeps_shell_helper_optional(tmp_path, capsys):
+    from ares.cli.typer_main import _run_python_setup
+
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / "scripts" / "setup.sh").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    (tmp_path / ".env.example").write_text(
+        "ARES_SECRET_KEY=\nARES_ENCRYPTION_KEY=\nARES_DEFAULT_ADMIN_PASSWORD=\n",
+        encoding="utf-8",
+    )
+
+    _run_python_setup(root=tmp_path, platform_name="linux", os_name="posix")
+
+    output = capsys.readouterr().out
+    assert "Linux" in output
+    assert "Developer helper available: scripts/setup.sh (optional)." in output
+    assert "/bin/bash" not in output
+    assert (tmp_path / ".env").exists()


### PR DESCRIPTION
## Summary
- Prevent `ares doctor` from crashing when optional dependency imports raise normal exceptions such as OSError or RuntimeError.
- Report broken optional imports as readable WARN/FAIL messages and continue remaining checks.
- Switch doctor status markers to ASCII `[OK]`, `[WARN]`, and `[FAIL]` for Windows console compatibility.
- Route `ares-setup` through Python-native cross-platform setup logic.
- Avoid Bash/os.execv/subprocess shell routing for the installed setup entrypoint.
- Preserve POSIX `scripts/setup.sh` as an optional developer helper only.
- On Windows, skip POSIX shell setup with a clear message instead of malformed `/bin/bash` path errors.

## Validation
- python -m compileall ares tests
- pytest tests\unit\test_cli_doctor.py -q --tb=short --timeout=60 --timeout-method=thread --maxfail=1
- pytest tests\unit -q --tb=short --timeout=60 --timeout-method=thread --maxfail=1
- .\.venv\Scripts\ares.exe doctor
- .\.venv\Scripts\ares-setup.exe

## Results
- compileall: passed
- test_cli_doctor.py: 5 passed
- full unit suite: 1131 passed, 98 warnings
- ares doctor: no traceback; 20/27 checks OK, 7 optional warnings
- ares-setup: exit 0 on Windows; no Bash invocation; .env preserved