### PR TITLE
ux: improve notification read and dismiss behavior

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,7 +5,6 @@ import {
   Bell,
   Boxes,
   CheckCircle2,
-  CircleDot,
   Copy,
   Database,
   Download,
@@ -370,6 +369,8 @@ function ProtectedShell() {
   const [searchTerm, setSearchTerm] = useState("");
   const [searchOpen, setSearchOpen] = useState(false);
   const [notificationsOpen, setNotificationsOpen] = useState(false);
+  const [readNotificationIds, setReadNotificationIds] = useState<string[]>([]);
+  const [deletedNotificationIds, setDeletedNotificationIds] = useState<string[]>([]);
   const liveSocketRef = useRef<WebSocket | null>(null);
   const health = useQuery({ queryKey: ["health"], queryFn: api.health });
   const telemetry = useQuery({ queryKey: ["telemetry"], queryFn: api.telemetry });
@@ -537,21 +538,21 @@ function ProtectedShell() {
     const healthStatus = String(health.data?.status ?? "").toLowerCase();
 
     if (health.isError) {
-      items.push({ id: "health-error", title: "Backend health check failed", detail: "ARES API health is not reachable.", tone: "danger" });
+      items.push({ id: "health:error", title: "Backend health check failed", detail: "ARES API health is not reachable.", tone: "danger" });
     } else if (health.isSuccess && healthStatus && !["ok", "healthy", "online"].includes(healthStatus)) {
-      items.push({ id: "health-status", title: "Backend status needs attention", detail: String(health.data?.status), tone: "warn" });
+      items.push({ id: `health:status:${healthStatus}`, title: "Backend status needs attention", detail: String(health.data?.status), tone: "warn" });
     }
     if (telemetry.isError) {
-      items.push({ id: "telemetry-error", title: "Telemetry unavailable", detail: "Runtime telemetry could not be loaded.", tone: "warn" });
+      items.push({ id: "telemetry:error", title: "Telemetry unavailable", detail: "Runtime telemetry could not be loaded.", tone: "warn" });
     }
     if (campaigns.isError) {
-      items.push({ id: "campaigns-error", title: "Campaign list unavailable", detail: "Campaign data could not be loaded.", tone: "warn" });
+      items.push({ id: "campaigns:error", title: "Campaign list unavailable", detail: "Campaign data could not be loaded.", tone: "warn" });
     }
     if (modules.isError) {
-      items.push({ id: "modules-error", title: "Module catalog unavailable", detail: "Module metadata could not be loaded.", tone: "warn" });
+      items.push({ id: "modules:error", title: "Module catalog unavailable", detail: "Module metadata could not be loaded.", tone: "warn" });
     }
     if (reports.isError && selectedCampaignId) {
-      items.push({ id: "reports-error", title: "Report library unavailable", detail: "Selected campaign reports could not be loaded.", tone: "warn" });
+      items.push({ id: `reports:error:${selectedCampaignId}`, title: "Report library unavailable", detail: "Selected campaign reports could not be loaded.", tone: "warn" });
     }
 
     const failedRuns = metricNumber(snapshot?.modules, "failed");
@@ -559,19 +560,57 @@ function ProtectedShell() {
     const unhealthyWorkers = metricNumber(snapshot?.workers, "unhealthy");
     const queueDepth = metricNumber(snapshot?.queue, "depth");
     if (failedRuns > 0) {
-      items.push({ id: "failed-runs", title: "Failed module runs", detail: `${failedRuns} failed module run(s) reported by telemetry.`, tone: "warn" });
+      items.push({ id: `telemetry:failed-runs:${failedRuns}`, title: "Failed module runs", detail: `${failedRuns} failed module run(s) reported by telemetry.`, tone: "warn" });
     }
     if (errorRate > 0) {
-      items.push({ id: "error-rate", title: "Runtime error rate above zero", detail: `${formatRate(errorRate)} module error rate.`, tone: "warn" });
+      items.push({ id: `telemetry:error-rate:${errorRate}`, title: "Runtime error rate above zero", detail: `${formatRate(errorRate)} module error rate.`, tone: "warn" });
     }
     if (unhealthyWorkers > 0) {
-      items.push({ id: "workers", title: "Unhealthy worker detected", detail: `${unhealthyWorkers} worker(s) unhealthy.`, tone: "danger" });
+      items.push({ id: `telemetry:workers:${unhealthyWorkers}`, title: "Unhealthy worker detected", detail: `${unhealthyWorkers} worker(s) unhealthy.`, tone: "danger" });
     }
     if (queueDepth > 0) {
-      items.push({ id: "queue", title: "Queue has pending work", detail: `${queueDepth} queued task(s).`, tone: "info" });
+      items.push({ id: `telemetry:queue:${queueDepth}`, title: "Queue has pending work", detail: `${queueDepth} queued task(s).`, tone: "info" });
     }
     return items;
   }, [campaigns.isError, health.data, health.isError, health.isSuccess, modules.isError, reports.isError, selectedCampaignId, telemetry.data, telemetry.isError]);
+
+  const activeNotificationKey = useMemo(() => notifications.map((item) => item.id).join("|"), [notifications]);
+  const visibleNotifications = useMemo(
+    () => notifications.filter((item) => !deletedNotificationIds.includes(item.id)),
+    [deletedNotificationIds, notifications]
+  );
+  const unreadNotificationCount = visibleNotifications.filter((item) => !readNotificationIds.includes(item.id)).length;
+
+  useEffect(() => {
+    const activeIds = activeNotificationKey ? activeNotificationKey.split("|") : [];
+    setReadNotificationIds((current) => current.filter((id) => activeIds.includes(id)));
+    setDeletedNotificationIds((current) => current.filter((id) => activeIds.includes(id)));
+  }, [activeNotificationKey]);
+
+  function markVisibleNotificationsRead(): void {
+    const visibleIds = visibleNotifications.map((item) => item.id);
+    if (visibleIds.length === 0) return;
+    setReadNotificationIds((current) => unique([...current, ...visibleIds]));
+  }
+
+  function toggleNotifications(): void {
+    const nextOpen = !notificationsOpen;
+    if (nextOpen) {
+      markVisibleNotificationsRead();
+    }
+    setNotificationsOpen(nextOpen);
+  }
+
+  function deleteNotification(id: string): void {
+    setDeletedNotificationIds((current) => unique([...current, id]));
+    setReadNotificationIds((current) => unique([...current, id]));
+  }
+
+  function clearNotifications(): void {
+    const visibleIds = visibleNotifications.map((item) => item.id);
+    setDeletedNotificationIds((current) => unique([...current, ...visibleIds]));
+    setReadNotificationIds((current) => unique([...current, ...visibleIds]));
+  }
 
   function selectSearchResult(result: SearchResult): void {
     result.onSelect?.();
@@ -673,33 +712,42 @@ function ProtectedShell() {
               </div>
             </div>
             <div className="topbar-right">
-              <span className={liveConnected ? "status-pill status-low" : "status-pill"}>
-                <CircleDot size={11} /> {liveConnected ? "Live" : "Offline"}
-              </span>
               <button
                 className="icon-button has-badge"
                 aria-expanded={notificationsOpen}
                 aria-label="Notifications"
-                onClick={() => setNotificationsOpen((value) => !value)}
+                onClick={toggleNotifications}
                 type="button"
               >
                 <Bell size={16} />
-                {notifications.length > 0 ? <span>{notifications.length}</span> : null}
+                {unreadNotificationCount > 0 ? <span>{unreadNotificationCount}</span> : null}
               </button>
               {notificationsOpen && (
                 <aside className="notification-drawer" aria-label="Notifications">
-                  <SectionHeader title="Notifications" action={<span className="badge">{notifications.length}</span>} />
-                  {notifications.length > 0 ? (
+                  <SectionHeader
+                    title="Notifications"
+                    action={visibleNotifications.length > 0 ? (
+                      <button className="btn btn-compact" onClick={clearNotifications} type="button">
+                        Clear all
+                      </button>
+                    ) : <span className="badge">0</span>}
+                  />
+                  {visibleNotifications.length > 0 ? (
                     <div className="notification-list">
-                      {notifications.map((item) => (
+                      {visibleNotifications.map((item) => (
                         <div className={`notification-item notification-${item.tone}`} key={item.id}>
-                          <strong>{item.title}</strong>
-                          <span>{item.detail}</span>
+                          <div className="notification-item-header">
+                            <strong>{item.title}</strong>
+                            <button className="icon-button icon-button-small" aria-label={`Dismiss ${item.title}`} onClick={() => deleteNotification(item.id)} type="button">
+                              <Trash2 size={14} />
+                            </button>
+                          </div>
+                          <p>{item.detail}</p>
                         </div>
                       ))}
                     </div>
                   ) : (
-                    <EmptyState text="No current dashboard notifications." />
+                    <EmptyState text="No notifications." />
                   )}
                 </aside>
               )}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -302,6 +302,11 @@ button:disabled {
   background: #f1f5f9;
 }
 
+.icon-button-small {
+  height: 28px;
+  width: 28px;
+}
+
 .icon-button.has-badge > span {
   position: absolute;
   right: -0.32rem;
@@ -338,11 +343,18 @@ button:disabled {
 
 .notification-item {
   display: grid;
-  gap: 0.2rem;
+  gap: 0.35rem;
   border: 1px solid #e5e7eb;
   border-radius: 6px;
   background: #fbfdff;
   padding: 0.62rem;
+}
+
+.notification-item-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.55rem;
 }
 
 .notification-item strong {
@@ -351,10 +363,12 @@ button:disabled {
   font-weight: 650;
 }
 
-.notification-item span {
+.notification-item p {
+  margin: 0;
   color: #64748b;
   font-size: 0.78rem;
   font-weight: 500;
+  line-height: 1.35;
 }
 
 .notification-warn {
@@ -594,6 +608,12 @@ button:disabled {
 .btn:hover {
   border-color: #aeb9c8;
   background: #f8fafc;
+}
+
+.btn-compact {
+  min-height: 30px;
+  padding: 0.35rem 0.55rem;
+  font-size: 0.78rem;
 }
 
 .btn:disabled,


### PR DESCRIPTION
## Summary
- Remove the visible topbar Offline/Live status chip.
- Keep the notification bell as the single topbar status surface.
- Make bell badge represent unread notifications only.
- Mark current visible notifications as read when the drawer opens.
- Add per-notification dismiss behavior.
- Add Clear all for visible notifications.
- Keep dismissed notifications hidden while the same underlying condition remains active.

## Scope
- Frontend only.
- Changed:
  - frontend/src/App.tsx
  - frontend/src/styles.css
- No backend/API/CLI/auth/RBAC changes.
- No dependency changes.
- No fake notifications added.

## Privacy / Security
- Notification read/deleted state is session-only React state.
- No notification bodies, API keys, tokens, stack traces, raw payloads, or secrets are stored.
- API key modal/flow remains unchanged.

## Validation
- git diff --check: passed
- npm audit --omit=dev: 0 vulnerabilities
- npm run build: passed
- python -m compileall ares tests: passed
- pytest tests\unit -q --tb=short --timeout=60 --timeout-method=thread --maxfail=1: 1131 passed

## Manual Review
- Topbar no longer shows Offline/online chip.
- Bell opens notification drawer.
- Badge clears after opening drawer.
- Individual dismiss works.
- Clear all works.
- Dismissed notifications did not immediately reappear.
- Search/sidebar/API key/logout flows passed.
- Browser console errors: 0.

## Remaining Blockers
None confirmed.