### PR TITLE
docs: audit dashboard startup consistency

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -79,8 +79,16 @@ For repeated local use, copy `.env.example` to `.env`, fill these values once, a
 
 ## 4. Start The API And Dashboard
 
+Recommended local startup from the repository root:
+
 ```bash
 ares dashboard dev
+```
+
+Windows virtualenv example:
+
+```powershell
+.\.venv\Scripts\ares.exe dashboard dev
 ```
 
 This starts the FastAPI backend and the Vite dashboard dev server in one
@@ -92,8 +100,17 @@ terminal. It prints:
 - Login password: value of `ARES_DEFAULT_ADMIN_PASSWORD` in `.env`
 
 The launcher opens the dashboard by default and does not print the password
-value. Use `ares dashboard dev --no-open` to print the URL without opening a
-browser. If `frontend/node_modules` is missing, run:
+value.
+
+Useful launcher options:
+
+- `--no-open`: print the URL without opening a browser.
+- `--no-reload`: start uvicorn without reload.
+- `--api-host` / `--api-port`: change the backend bind address.
+- `--ui-host` / `--ui-port`: change the Vite bind address.
+- `--install`: run `npm ci` in `frontend/` if `node_modules` is missing.
+
+For example:
 
 ```bash
 ares dashboard dev --install
@@ -104,13 +121,14 @@ Manual fallback for troubleshooting:
 Terminal 1:
 
 ```powershell
+Set-Location C:\path\to\ARES
 .\.venv\Scripts\python.exe -m uvicorn ares.api.server:app --host 127.0.0.1 --port 8080 --reload
 ```
 
 Terminal 2:
 
 ```powershell
-cd frontend
+Set-Location C:\path\to\ARES\frontend
 "C:\Program Files\nodejs\npm.cmd" run dev -- --host 127.0.0.1 --port 5173
 ```
 

--- a/README.md
+++ b/README.md
@@ -426,8 +426,13 @@ missing, run `npm ci` in `frontend/` or start with:
 ares dashboard dev --install
 ```
 
-Use `--no-open` when you want the command to print the URL without opening a
-browser.
+Useful launcher options:
+
+- `--no-open`: print the URL without opening a browser.
+- `--no-reload`: start uvicorn without reload.
+- `--api-host` / `--api-port`: change the backend bind address.
+- `--ui-host` / `--ui-port`: change the Vite bind address.
+- `--install`: run `npm ci` in `frontend/` if `node_modules` is missing.
 
 Manual fallback for troubleshooting:
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -516,10 +516,15 @@ Auth: `?token=<access_token>` query param (WebSocket cannot send headers before 
 
 ## Dashboard
 
-The React dashboard is served at `GET /dashboard/`, with SPA fallback for
-routes like `/dashboard/campaigns`. The static shell can load without auth so
-the login screen works; all sensitive data is fetched from the main authenticated
-API routes above.
+After frontend assets are built, FastAPI serves the production/static React
+dashboard at `GET /dashboard/`, with SPA fallback for routes like
+`/dashboard/campaigns`. The static shell can load without auth so the login
+screen works; all sensitive data is fetched from the main authenticated API
+routes above.
+
+For local development, run `ares dashboard dev` from the repository root and
+open the Vite-served dashboard at `http://127.0.0.1:5173/dashboard/`. The
+backend API remains on `http://127.0.0.1:8080` by default.
 
 The dashboard uses `POST /auth/token`, `POST /auth/refresh`, the main REST API,
 and `WS /ws/campaigns/{campaign_id}/events?token=<token>`. Legacy

--- a/docs/dashboard-guide.md
+++ b/docs/dashboard-guide.md
@@ -17,6 +17,12 @@ Recommended local dashboard startup from the repository root:
 ares dashboard dev
 ```
 
+Windows virtualenv example:
+
+```powershell
+.\.venv\Scripts\ares.exe dashboard dev
+```
+
 This one-terminal launcher starts:
 
 - Backend API: `python -m uvicorn ares.api.server:app --host 127.0.0.1 --port 8080 --reload`
@@ -28,6 +34,9 @@ the value of `ARES_DEFAULT_ADMIN_PASSWORD` from `.env`; the launcher does not
 print that password. Use `ares dashboard dev --no-open` to skip browser open,
 or `ares dashboard dev --install` to run `npm ci` if `frontend/node_modules`
 is missing.
+
+Options: `--api-host`, `--api-port`, `--ui-host`, `--ui-port`, `--no-open`,
+`--no-reload`, and `--install`.
 
 Manual fallback for troubleshooting:
 

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -8,21 +8,27 @@ for the FastAPI backend.
 - Development: run `ares dashboard dev` from the repository root. It starts
   the FastAPI API on `http://127.0.0.1:8080` and the Vite dashboard on
   `http://127.0.0.1:5173/dashboard/` in one terminal.
+- Windows virtualenv: `.\.venv\Scripts\ares.exe dashboard dev`.
 - Browser open can be skipped with `ares dashboard dev --no-open`.
+- Backend and UI bind addresses can be changed with `--api-host`,
+  `--api-port`, `--ui-host`, and `--ui-port`.
+- Uvicorn reload can be disabled with `--no-reload`.
 - If `frontend/node_modules` is missing, run `ares dashboard dev --install` or
-  `cd frontend && npm ci`.
-- Production: `npm run build`, then FastAPI serves `frontend/dist` at `/dashboard`
+  run `npm ci` from `frontend/`.
+- Production/static serving: `npm run build`, then FastAPI serves
+  `frontend/dist` at `/dashboard`
 - Vite base path: `/dashboard/`
 - API proxy: main FastAPI routes, not legacy dashboard shadow routes
 
 Manual fallback for troubleshooting:
 
 ```powershell
+Set-Location C:\path\to\ARES
 .\.venv\Scripts\python.exe -m uvicorn ares.api.server:app --host 127.0.0.1 --port 8080 --reload
 ```
 
 ```powershell
-cd frontend
+Set-Location C:\path\to\ARES\frontend
 "C:\Program Files\nodejs\npm.cmd" run dev -- --host 127.0.0.1 --port 5173
 ```
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -149,7 +149,9 @@ The first account is bootstrapped as:
 ARES creates that account only when the user table is empty. Changing
 `ARES_DEFAULT_ADMIN_PASSWORD` after the `admin` account exists does not reset
 the password. Use the Security page after login for normal password changes,
-or recreate the local database only when disposable local data can be lost.
+or recreate the local `ares.db` only when disposable local dashboard data can
+be lost. Do not use local database reset guidance on real or shared
+deployments.
 
 Additional accounts are created by a `team_lead` through `POST /auth/register`.
 The role is assigned at creation time:


### PR DESCRIPTION
## Summary
- Run repo-wide docs consistency audit after `ares dashboard dev` landed.
- Clarify one-command local dashboard startup.
- Document Windows venv usage: `.\.venv\Scripts\ares.exe dashboard dev`.
- Document launcher options: `--api-host`, `--api-port`, `--ui-host`, `--ui-port`, `--no-open`, `--no-reload`, `--install`.
- Separate local Vite dev URL from production/static FastAPI `/dashboard`.
- Strengthen admin bootstrap and local `ares.db` reset warnings.

## Scope
- Documentation only.
- No backend API behavior changes.
- No frontend UI behavior changes.
- No dependency changes.

## Files Changed
- `README.md`
- `QUICKSTART.md`
- `docs/api-reference.md`
- `docs/dashboard-guide.md`
- `docs/frontend.md`
- `docs/security-model.md`

## Validation
- `git diff --check`: passed
- `npm audit --omit=dev`: 0 vulnerabilities
- `npm run build`: passed
- `python -m compileall ares tests`: passed
- `pytest tests\unit -q --tb=short --timeout=60 --timeout-method=thread --maxfail=1`: 1137 passed

## Manual Launcher Validation
- `.\.venv\Scripts\ares.exe dashboard dev --no-open`: passed
- Backend and frontend started
- Dashboard URL loaded
- `/health` returned OK
- Shutdown left no listeners on 8080/5173
- No uvicorn/vite/npm orphan processes remained