### PR TITLE
docs: normalize local API examples

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -81,7 +81,7 @@ PowerShell example:
 ```powershell
 $token = (Invoke-RestMethod `
   -Method Post `
-  -Uri http://localhost:8080/auth/token `
+  -Uri http://127.0.0.1:8080/auth/token `
   -ContentType "application/x-www-form-urlencoded" `
   -Body "username=admin&password=YOUR_CURRENT_ADMIN_PASSWORD").access_token
 
@@ -89,7 +89,7 @@ $headers = @{ Authorization = "Bearer $token" }
 
 Invoke-RestMethod `
   -Method Post `
-  -Uri http://localhost:8080/auth/register `
+  -Uri http://127.0.0.1:8080/auth/register `
   -Headers $headers `
   -ContentType "application/json" `
   -Body (@{

--- a/docs/dashboard-guide.md
+++ b/docs/dashboard-guide.md
@@ -149,7 +149,7 @@ PowerShell example:
 ```powershell
 $token = (Invoke-RestMethod `
   -Method Post `
-  -Uri http://localhost:8080/auth/token `
+  -Uri http://127.0.0.1:8080/auth/token `
   -ContentType "application/x-www-form-urlencoded" `
   -Body "username=admin&password=YOUR_CURRENT_ADMIN_PASSWORD").access_token
 
@@ -157,7 +157,7 @@ $headers = @{ Authorization = "Bearer $token" }
 
 Invoke-RestMethod `
   -Method Post `
-  -Uri http://localhost:8080/auth/register `
+  -Uri http://127.0.0.1:8080/auth/register `
   -Headers $headers `
   -ContentType "application/json" `
   -Body (@{

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -53,7 +53,7 @@ authorization and a scoped campaign.
 ```powershell
 $token = (Invoke-RestMethod `
   -Method Post `
-  -Uri http://localhost:8080/auth/token `
+  -Uri http://127.0.0.1:8080/auth/token `
   -ContentType "application/x-www-form-urlencoded" `
   -Body "username=admin&password=YOUR_PASSWORD").access_token
 

--- a/docs/validation-lab.md
+++ b/docs/validation-lab.md
@@ -22,7 +22,7 @@ Start ARES first:
 $bytes = [byte[]]::new(32)
 [System.Security.Cryptography.RandomNumberGenerator]::Fill($bytes)
 $env:ARES_SECRET_KEY = -join ($bytes | ForEach-Object { $_.ToString("x2") })
-$env:ARES_ENCRYPTION_KEY = .\.venv\Scripts\python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+$env:ARES_ENCRYPTION_KEY = .\.venv\Scripts\python.exe -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 $env:ARES_DEFAULT_ADMIN_PASSWORD = "replace-with-your-own-strong-admin-password"
 .\.venv\Scripts\ares-api.exe
 ```


### PR DESCRIPTION
## Summary
- Normalize local API examples from `localhost:8080` to `127.0.0.1:8080`.
- Make Windows venv Python command consistent with `python.exe` in validation-lab docs.

## Scope
- Documentation only.
- No code behavior changes.
- No dependency changes.

## Validation
- `git diff --check`: passed
- stale grep for old dashboard/auth/password/variation strings: no matches
- target grep confirms `127.0.0.1:8080/auth` and `.\.venv\Scripts\python.exe -c` examples