### PR TITLE
fix: clarify dashboard password source

### DIFF
--- a/ares/cli/typer_main.py
+++ b/ares/cli/typer_main.py
@@ -1610,7 +1610,7 @@ def _run_dashboard_dev(
     console.print(f"Backend API URL: {backend_url}")
     console.print(f"Dashboard URL: {dashboard_url}")
     console.print("Login username: admin")
-    console.print("Login password: value of ARES_DEFAULT_ADMIN_PASSWORD in .env (not printed)")
+    console.print("Password source: ARES_DEFAULT_ADMIN_PASSWORD from current environment or .env")
     if not (root_path / ".env").exists():
         console.print("[yellow]Warning:[/yellow] .env was not found in the repo root.")
     console.print()

--- a/tests/unit/test_dashboard_dev_launcher.py
+++ b/tests/unit/test_dashboard_dev_launcher.py
@@ -211,5 +211,8 @@ def test_dashboard_dev_launches_both_processes_and_cleans_up(monkeypatch, tmp_pa
     output = capsys.readouterr().out
     assert "Dashboard URL: http://127.0.0.1:5173/dashboard/" in output
     assert "Login username: admin" in output
-    assert "Login password: value of ARES_DEFAULT_ADMIN_PASSWORD in .env" in output
+    assert (
+        "Password source: ARES_DEFAULT_ADMIN_PASSWORD from current environment or .env"
+        in output
+    )
     assert "DoNotPrintThisSecret123!" not in output


### PR DESCRIPTION
## Summary
- Clarify dashboard launcher password-source wording.
- State that `ARES_DEFAULT_ADMIN_PASSWORD` can come from the current environment or `.env`.
- Keep secret-not-printed behavior covered by tests.

## Validation
- `git diff --check`: passed
- `tests/unit/test_dashboard_dev_launcher.py`: 6 passed