### PR TITLE
docs: clean stale architecture references

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # ARES Architecture
 
-**Version:** 0.9.0 | **Status:** Active Development
+**Version:** 6.0.0 | **Status:** Active Development
 
 ## Overview
 
@@ -302,5 +302,5 @@ ARES/
 ├── tests/
 │   ├── unit/           pytest unit tests (test_v5 through test_v9)
 │   └── integration/    End-to-end campaign tests
-└── docker/             Dockerfile, docker-compose.yml
+└── docker/             Dockerfiles, docker/docker-compose.dev.yml, docker/docker-compose.prod.yml
 ```

--- a/docs/worker_architecture.md
+++ b/docs/worker_architecture.md
@@ -254,4 +254,5 @@ ARES_REDIS_URL=redis://redis:6379 ares worker start --capabilities cloud
 ```
 
 Workers auto-register and receive tasks matching their capability set.
-For Docker deployment, see `docker-compose.yml` in project root.
+For Docker deployment, see `docker/docker-compose.prod.yml`; for local Docker
+development, see `docker/docker-compose.dev.yml`.


### PR DESCRIPTION
## Summary
- Replace stale root `docker-compose.yml` references with the actual compose files under `docker/`.
- Align `docs/architecture.md` version text with project version `6.0.0`.

## Validation
- `git diff --check`: passed
- grep for `docker-compose.yml` in README/QUICKSTART/docs/docker: no matches
- stale docs version `0.9.0` removed from architecture docs
- remaining `v0.9.0+` references are SDK/interface compatibility markers and intentionally unchanged