### PR TITLE
Derive overview telemetry from persisted execution data

### DIFF
--- a/ares/api/server.py
+++ b/ares/api/server.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import time
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -122,6 +123,56 @@ def _finding_from_db_row(row: dict[str, Any], *, report_confirmed: bool = False)
     if row.get("discovered_at"):
         data["discovered_at"] = row["discovered_at"]
     return Finding(**data)
+
+
+_SUCCESSFUL_MODULE_OUTCOMES = {
+    "modulestatus.done",
+    "done",
+    "success",
+    "partial",
+    "confirmed_findings",
+    "completed_no_findings",
+    "dry_run_ok",
+}
+
+
+def _module_outcome_value(value: Any) -> str:
+    """Normalize enum/string result values for telemetry classification."""
+    enum_value = getattr(value, "value", None)
+    if enum_value is not None:
+        value = enum_value
+    return str(value or "").strip().lower()
+
+
+def _is_successful_module_outcome(status: Any) -> bool:
+    """Return whether a module outcome is operationally successful."""
+    return _module_outcome_value(status) in _SUCCESSFUL_MODULE_OUTCOMES
+
+
+async def _record_module_run(
+    db: AresDatabase,
+    campaign_id: str,
+    module_id: str,
+    *,
+    outcome: str,
+    success: bool,
+    duration_ms: float,
+) -> None:
+    """Persist only safe execution metadata; telemetry must not block the result."""
+    try:
+        await db.record_module_run(
+            campaign_id=campaign_id,
+            module_id=module_id,
+            outcome=str(outcome)[:64],
+            success=success,
+            duration_ms=duration_ms,
+        )
+    except Exception as exc:
+        logger.warning(
+            "module_run_telemetry_persist_failed",
+            module_id=module_id,
+            error=str(exc)[:120],
+        )
 
 
 async def _campaign_for_report(db: AresDatabase, row: dict[str, Any]) -> Campaign:
@@ -1310,8 +1361,36 @@ async def run_module(
     if getattr(body, "dry_run", False):
         return engine.dry_run_module(module_id, safe_params)
 
-    result = await engine.run_module(
-        module_id, c_obj, safe_params, actor_role=actor.role
+    run_started = time.monotonic()
+    try:
+        result = await engine.run_module(
+            module_id, c_obj, safe_params, actor_role=actor.role
+        )
+    except Exception:
+        await _record_module_run(
+            db,
+            body.campaign_id,
+            module_id,
+            outcome="error",
+            success=False,
+            duration_ms=(time.monotonic() - run_started) * 1000,
+        )
+        raise
+
+    status = _module_outcome_value(getattr(result, "status", ""))
+    outcome = _module_outcome_value(getattr(result, "outcome", "")) or status
+    success = _is_successful_module_outcome(outcome)
+    run_duration_ms = float(getattr(result, "duration_ms", 0.0) or 0.0)
+    if run_duration_ms <= 0.0:
+        run_duration_ms = max(0.0, (time.monotonic() - run_started) * 1000)
+        result.duration_ms = run_duration_ms
+    await _record_module_run(
+        db,
+        body.campaign_id,
+        module_id,
+        outcome=outcome or "unknown",
+        success=success,
+        duration_ms=run_duration_ms,
     )
     await db.audit(
         actor.username, "module_run", f"module={module_id}", body.campaign_id, module_id
@@ -1321,11 +1400,9 @@ async def run_module(
     try:
         from ares.telemetry.collector import get_collector
 
-        status = str(getattr(result, "status", "")).lower()
-        success = status in {"modulestatus.done", "done", "success", "partial"}
         get_collector().record_execution(
             module_id,
-            float(getattr(result, "duration_ms", 0.0) or 0.0),
+            run_duration_ms,
             success=success,
             campaign_id=body.campaign_id,
         )
@@ -2091,10 +2168,27 @@ async def get_monthly_stats(
 @app.get("/telemetry", tags=["telemetry"])
 async def get_telemetry(
     actor: AuthenticatedUser = _api_key_read_dep,
+    db: AresDatabase = Depends(get_db),
 ) -> dict[str, Any]:
     from ares.telemetry.collector import get_collector
 
-    return get_collector().snapshot().to_dict()
+    snapshot = get_collector().snapshot().to_dict()
+    try:
+        persisted = await db.get_telemetry_stats()
+    except Exception as exc:
+        logger.warning("telemetry_persisted_aggregate_failed", error=str(exc)[:120])
+        return snapshot
+
+    for key in ("modules", "latency_ms", "throughput", "hosts"):
+        if isinstance(persisted.get(key), dict):
+            current = snapshot.get(key)
+            snapshot[key] = {
+                **(current if isinstance(current, dict) else {}),
+                **persisted[key],
+            }
+    if isinstance(persisted.get("findings"), int):
+        snapshot["findings"] = persisted["findings"]
+    return snapshot
 
 
 @app.get("/telemetry/prometheus", tags=["telemetry"])
@@ -2283,6 +2377,17 @@ async def run_campaign_plan(
 
     c_obj = _campaign_from_db_row(campaign)
     results = await engine.run_plan(plan, c_obj, body.global_params, actor_role=actor.role)
+    for module_id, result in results.items():
+        status = _module_outcome_value(getattr(result, "status", ""))
+        outcome = _module_outcome_value(getattr(result, "outcome", "")) or status
+        await _record_module_run(
+            db,
+            campaign_id,
+            module_id,
+            outcome=outcome or "unknown",
+            success=_is_successful_module_outcome(outcome),
+            duration_ms=float(getattr(result, "duration_ms", 0.0) or 0.0),
+        )
     return {
         "campaign_id": campaign_id,
         "modules_run": len(results),

--- a/ares/db/database.py
+++ b/ares/db/database.py
@@ -175,6 +175,25 @@ class AresDatabase:
         await self._conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_findings_cvss ON findings(cvss_score)"
         )
+        await self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS module_runs (
+                id           TEXT PRIMARY KEY,
+                campaign_id  TEXT NOT NULL REFERENCES campaigns(id) ON DELETE CASCADE,
+                module_id    TEXT NOT NULL,
+                outcome      TEXT NOT NULL,
+                success      INTEGER NOT NULL DEFAULT 0,
+                duration_ms  REAL NOT NULL DEFAULT 0.0,
+                completed_at TEXT NOT NULL DEFAULT (datetime('now'))
+            )
+            """
+        )
+        await self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_module_runs_campaign ON module_runs(campaign_id)"
+        )
+        await self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_module_runs_completed ON module_runs(completed_at)"
+        )
         await self._conn.commit()
 
     async def _run_alembic_migrations(self) -> bool:
@@ -441,6 +460,15 @@ class AresDatabase:
         period = datetime.now(timezone.utc).strftime("%Y-%m")
         async with self._conn.execute(
             """
+            SELECT COUNT(*) AS n
+            FROM findings
+            WHERE validated=1
+              AND false_positive=0
+            """
+        ) as cur:
+            confirmed_findings = int((await cur.fetchone())["n"])
+        async with self._conn.execute(
+            """
             SELECT substr(discovered_at, 1, 10) AS finding_date, COUNT(*) AS n
             FROM findings
             WHERE validated=1
@@ -460,7 +488,94 @@ class AresDatabase:
             "period": period,
             "label": "Security signals this cycle",
             "total": sum(item["count"] for item in series),
+            "confirmed_findings": confirmed_findings,
             "series": series,
+        }
+
+    async def record_module_run(
+        self,
+        campaign_id: str,
+        module_id: str,
+        outcome: str,
+        success: bool,
+        duration_ms: float,
+    ) -> None:
+        """Persist non-sensitive execution metadata for restart-safe telemetry."""
+        await self._conn.execute(
+            """
+            INSERT INTO module_runs
+                (id, campaign_id, module_id, outcome, success, duration_ms, completed_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                str(uuid.uuid4()),
+                campaign_id,
+                module_id,
+                outcome,
+                int(bool(success)),
+                max(0.0, float(duration_ms or 0.0)),
+                datetime.now(timezone.utc).isoformat(),
+            ),
+        )
+        await self._conn.commit()
+
+    async def get_telemetry_stats(self) -> dict[str, Any]:
+        """Aggregate persisted execution, finding, and discovered-host telemetry."""
+        async with self._conn.execute(
+            "SELECT success, duration_ms, completed_at FROM module_runs ORDER BY completed_at"
+        ) as cur:
+            run_rows = await cur.fetchall()
+
+        total = len(run_rows)
+        success = sum(int(row["success"]) for row in run_rows)
+        failed = total - success
+        durations = sorted(float(row["duration_ms"] or 0.0) for row in run_rows)
+
+        def percentile(fraction: float) -> float | None:
+            if not durations:
+                return None
+            index = max(0, min(len(durations) - 1, int(len(durations) * fraction + 0.999999) - 1))
+            return round(durations[index], 1)
+
+        recent_cutoff = (
+            datetime.now(timezone.utc) - timedelta(seconds=60)
+        ).isoformat()
+        recent_runs = sum(
+            1 for row in run_rows if str(row["completed_at"]) >= recent_cutoff
+        )
+
+        async with self._conn.execute(
+            """
+            SELECT COUNT(*) AS n
+            FROM findings
+            WHERE validated=1 AND false_positive=0
+            """
+        ) as cur:
+            confirmed_findings = int((await cur.fetchone())["n"])
+        async with self._conn.execute("SELECT COUNT(*) AS n FROM hosts") as cur:
+            discovered_hosts = int((await cur.fetchone())["n"])
+
+        return {
+            "modules": {
+                "total": total,
+                "success": success,
+                "failed": failed,
+                "error_rate": failed / total if total else 0.0,
+            },
+            "findings": confirmed_findings,
+            "latency_ms": {
+                "p50": percentile(0.50),
+                "p95": percentile(0.95),
+                "p99": percentile(0.99),
+            },
+            "throughput": {
+                "tasks_per_min": float(recent_runs) if recent_runs else None,
+            },
+            "hosts": {
+                "available": False,
+                "discovered": discovered_hosts,
+                "owned": None,
+            },
         }
 
     async def campaign_summary(self, campaign_id: str) -> dict[str, Any]:

--- a/ares/db/postgres.py
+++ b/ares/db/postgres.py
@@ -58,6 +58,18 @@ CREATE TABLE IF NOT EXISTS campaigns (
     updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
+CREATE TABLE IF NOT EXISTS module_runs (
+    id              TEXT PRIMARY KEY,
+    campaign_id     TEXT NOT NULL REFERENCES campaigns(id) ON DELETE CASCADE,
+    module_id       TEXT NOT NULL,
+    outcome         TEXT NOT NULL,
+    success         INTEGER NOT NULL DEFAULT 0,
+    duration_ms     DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+    completed_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_pg_module_runs_campaign ON module_runs(campaign_id);
+CREATE INDEX IF NOT EXISTS idx_pg_module_runs_completed ON module_runs(completed_at);
+
 CREATE TABLE IF NOT EXISTS findings (
     id              TEXT PRIMARY KEY,
     campaign_id     TEXT NOT NULL REFERENCES campaigns(id) ON DELETE CASCADE,
@@ -432,6 +444,14 @@ class PostgresDatabase:
             next_month = period_start.replace(month=period_start.month + 1)
         period = period_start.strftime("%Y-%m")
         async with self._pool.acquire() as conn:
+            confirmed_findings = await conn.fetchval(
+                """
+                SELECT COUNT(*)
+                FROM findings
+                WHERE validated=1
+                  AND false_positive=0
+                """
+            )
             rows = await conn.fetch(
                 """
                 SELECT (discovered_at AT TIME ZONE 'UTC')::date AS finding_date,
@@ -455,10 +475,94 @@ class PostgresDatabase:
             "period": period,
             "label": "Security signals this cycle",
             "total": sum(item["count"] for item in series),
+            "confirmed_findings": int(confirmed_findings or 0),
             "series": series,
         }
 
     # ── Hosts ──────────────────────────────────────────────────────────────────
+
+    async def record_module_run(
+        self,
+        campaign_id: str,
+        module_id: str,
+        outcome: str,
+        success: bool,
+        duration_ms: float,
+    ) -> None:
+        """Persist non-sensitive execution metadata for restart-safe telemetry."""
+        async with self._pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO module_runs
+                    (id, campaign_id, module_id, outcome, success, duration_ms, completed_at)
+                VALUES ($1, $2, $3, $4, $5, $6, $7)
+                """,
+                str(uuid.uuid4()),
+                campaign_id,
+                module_id,
+                outcome,
+                int(bool(success)),
+                max(0.0, float(duration_ms or 0.0)),
+                datetime.now(timezone.utc),
+            )
+
+    async def get_telemetry_stats(self) -> dict[str, Any]:
+        """Aggregate persisted execution, finding, and discovered-host telemetry."""
+        async with self._pool.acquire() as conn:
+            run_rows = await conn.fetch(
+                "SELECT success, duration_ms, completed_at FROM module_runs ORDER BY completed_at"
+            )
+            confirmed_findings = int(
+                await conn.fetchval(
+                    """
+                    SELECT COUNT(*)
+                    FROM findings
+                    WHERE validated=1 AND false_positive=0
+                    """
+                )
+                or 0
+            )
+            discovered_hosts = int(await conn.fetchval("SELECT COUNT(*) FROM hosts") or 0)
+
+        total = len(run_rows)
+        success = sum(int(row["success"]) for row in run_rows)
+        failed = total - success
+        durations = sorted(float(row["duration_ms"] or 0.0) for row in run_rows)
+
+        def percentile(fraction: float) -> float | None:
+            if not durations:
+                return None
+            index = max(0, min(len(durations) - 1, int(len(durations) * fraction + 0.999999) - 1))
+            return round(durations[index], 1)
+
+        recent_cutoff = datetime.now(timezone.utc) - timedelta(seconds=60)
+        recent_runs = sum(
+            1
+            for row in run_rows
+            if row["completed_at"] is not None and row["completed_at"] >= recent_cutoff
+        )
+        return {
+            "modules": {
+                "total": total,
+                "success": success,
+                "failed": failed,
+                "error_rate": failed / total if total else 0.0,
+            },
+            "findings": confirmed_findings,
+            "latency_ms": {
+                "p50": percentile(0.50),
+                "p95": percentile(0.95),
+                "p99": percentile(0.99),
+            },
+            "throughput": {
+                "tasks_per_min": float(recent_runs) if recent_runs else None,
+            },
+            "hosts": {
+                "available": False,
+                "discovered": discovered_hosts,
+                "owned": None,
+            },
+        }
 
     async def upsert_host(self, h: Any) -> str:
         async with self._pool.acquire() as conn:

--- a/ares/db/schema.py
+++ b/ares/db/schema.py
@@ -43,6 +43,20 @@ CREATE TABLE IF NOT EXISTS campaigns (
 );
 
 -- ── Findings ─────────────────────────────────────────────────────────────────
+-- Module execution history (non-sensitive telemetry metadata)
+CREATE TABLE IF NOT EXISTS module_runs (
+    id              TEXT PRIMARY KEY,
+    campaign_id     TEXT NOT NULL REFERENCES campaigns(id) ON DELETE CASCADE,
+    module_id       TEXT NOT NULL,
+    outcome         TEXT NOT NULL,
+    success         INTEGER NOT NULL DEFAULT 0,
+    duration_ms     REAL NOT NULL DEFAULT 0.0,
+    completed_at    TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_module_runs_campaign ON module_runs(campaign_id);
+CREATE INDEX IF NOT EXISTS idx_module_runs_completed ON module_runs(completed_at);
+
 CREATE TABLE IF NOT EXISTS findings (
     id              TEXT PRIMARY KEY,
     campaign_id     TEXT NOT NULL REFERENCES campaigns(id) ON DELETE CASCADE,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -165,7 +165,7 @@ function useSessionState<T>(key: string, initialValue: T): readonly [T, Dispatch
 const REQUIRED_FIELD_MESSAGE = "This field is required.";
 
 type ValidatableElement = HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement;
-type TelemetryMetricMap = Record<string, number | string | undefined>;
+type TelemetryMetricMap = Record<string, boolean | number | string | null | undefined>;
 interface TelemetrySnapshot {
   modules?: TelemetryMetricMap;
   queue?: TelemetryMetricMap;
@@ -855,7 +855,7 @@ function OverviewPage() {
   const monthlyData = monthlyStats.data as MonthlyFindingStats | undefined;
   const campaignList = campaigns.data ?? [];
   const activeCampaigns = campaignList.filter((campaign) => String(campaign.status ?? "").toLowerCase() !== "deleted").length;
-  const findings = typeof snapshot?.findings === "number" ? snapshot.findings : 0;
+  const findings = typeof monthlyData?.confirmed_findings === "number" ? monthlyData.confirmed_findings : 0;
   const monthlyTotal = typeof monthlyData?.total === "number" ? monthlyData.total : 0;
   const monthlySeries = normalizeMonthlySeries(monthlyData?.period, monthlyData?.series);
   return (
@@ -863,7 +863,7 @@ function OverviewPage() {
       title="Overview"
     >
       <div className="dashboard-grid">
-        <TelemetryPanel snapshot={snapshot} loading={telemetry.isLoading} />
+        <TelemetryPanel snapshot={snapshot} loading={telemetry.isLoading} confirmedFindings={findings} />
         <div className="side-stack">
           <section className="panel p-4">
             <SectionHeader title="Highlights" />
@@ -1150,6 +1150,7 @@ function ExecutionChainsPanel({
 
 function ModulesPage() {
   const { selectedCampaignId: campaignId, setSelectedCampaignId: setCampaignId } = useDashboardUi();
+  const queryClient = useQueryClient();
   const campaigns = useQuery({ queryKey: ["campaigns"], queryFn: api.campaigns });
   const modules = useQuery({ queryKey: ["modules"], queryFn: api.modules });
   const executionChains = useQuery({ queryKey: ["executionChains"], queryFn: api.executionChains });
@@ -1173,10 +1174,18 @@ function ModulesPage() {
     onSuccess: (payload) => {
       setLastRunRecord({ campaignId, moduleId: selectedId, payload });
       setActiveTab("Results");
+      if (!dryRun) {
+        void queryClient.invalidateQueries({ queryKey: ["telemetry"] });
+        void queryClient.invalidateQueries({ queryKey: ["monthlyStats"] });
+      }
     },
     onError: (error) => {
       setLastRunRecord({ campaignId, moduleId: selectedId, payload: serializeError(error), isError: true });
       setActiveTab("Results");
+      if (!dryRun) {
+        void queryClient.invalidateQueries({ queryKey: ["telemetry"] });
+        void queryClient.invalidateQueries({ queryKey: ["monthlyStats"] });
+      }
     }
   });
   const list = modules.data ?? [];
@@ -2607,13 +2616,17 @@ function formatMonthlyDate(date: string): string {
 }
 
 function metricNumber(map: TelemetryMetricMap | undefined, key: string): number {
+  return metricNumberOrNull(map, key) ?? 0;
+}
+
+function metricNumberOrNull(map: TelemetryMetricMap | undefined, key: string): number | null {
   const value = map?.[key];
   if (typeof value === "number" && Number.isFinite(value)) return value;
-  if (typeof value === "string") {
+  if (typeof value === "string" && value.trim()) {
     const parsed = Number(value);
-    return Number.isFinite(parsed) ? parsed : 0;
+    return Number.isFinite(parsed) ? parsed : null;
   }
-  return 0;
+  return null;
 }
 
 function formatMetric(value: number, suffix = ""): string {
@@ -2654,20 +2667,28 @@ function formatReportDate(value: number): string {
   return new Date(timestamp).toLocaleString();
 }
 
-function TelemetryPanel({ snapshot, loading }: { snapshot?: TelemetrySnapshot; loading: boolean }) {
+function TelemetryPanel({ snapshot, loading, confirmedFindings }: { snapshot?: TelemetrySnapshot; loading: boolean; confirmedFindings: number }) {
   const total = metricNumber(snapshot?.modules, "total");
   const success = metricNumber(snapshot?.modules, "success");
   const failed = metricNumber(snapshot?.modules, "failed");
-  const findings = typeof snapshot?.findings === "number" ? snapshot.findings : 0;
-  const successRate = total > 0 ? Math.round((success / total) * 100) : 0;
-  const errorRate = metricNumber(snapshot?.modules, "error_rate");
-  const p95 = metricNumber(snapshot?.latency_ms, "p95");
+  const findings = confirmedFindings;
+  const successRate = total > 0 ? Math.round((success / total) * 100) : null;
+  const errorRate = total > 0 ? Math.min(100, Math.round(metricNumber(snapshot?.modules, "error_rate") * 100)) : null;
+  const p95 = metricNumberOrNull(snapshot?.latency_ms, "p95");
   const queueDepth = metricNumber(snapshot?.queue, "depth");
   const activeWorkers = metricNumber(snapshot?.workers, "active");
   const unhealthyWorkers = metricNumber(snapshot?.workers, "unhealthy");
   const hostsDiscovered = metricNumber(snapshot?.hosts, "discovered");
-  const hostsOwned = metricNumber(snapshot?.hosts, "owned");
-  const tasksPerMin = metricNumber(snapshot?.throughput, "tasks_per_min");
+  const hostsOwned = metricNumberOrNull(snapshot?.hosts, "owned");
+  const tasksPerMin = metricNumberOrNull(snapshot?.throughput, "tasks_per_min");
+  const workerTotal = activeWorkers + unhealthyWorkers;
+  const workerCapacity = workerTotal > 0 ? Math.round((activeWorkers / workerTotal) * 100) : null;
+  const hostsAvailable = snapshot?.hosts?.available === true;
+  const hostOwnership = hostsAvailable && hostsDiscovered > 0 && hostsOwned !== null
+    ? Math.round((hostsOwned / hostsDiscovered) * 100)
+    : null;
+  const throughputValue = tasksPerMin === null ? "n/a" : `${formatMetric(tasksPerMin)}/min`;
+  const latencyDetail = p95 === null ? "no run timing data" : `${formatMetric(p95, " ms")} p95`;
 
   return (
     <section className="panel telemetry-panel">
@@ -2679,22 +2700,22 @@ function TelemetryPanel({ snapshot, loading }: { snapshot?: TelemetrySnapshot; l
 
       <div className="telemetry-chart" aria-label="Runtime telemetry chart">
         <TelemetryBar label="Success rate" value={successRate} />
-        <TelemetryBar label="Error rate" value={Math.min(100, Math.round(errorRate * 100))} tone="danger" />
-        <TelemetryBar label="Worker capacity" value={activeWorkers + unhealthyWorkers > 0 ? Math.round((activeWorkers / (activeWorkers + unhealthyWorkers)) * 100) : 0} />
-        <TelemetryBar label="Host ownership" value={hostsDiscovered > 0 ? Math.round((hostsOwned / hostsDiscovered) * 100) : 0} tone={hostsOwned > 0 ? "danger" : "ok"} />
+        <TelemetryBar label="Error rate" value={errorRate} tone="danger" />
+        <TelemetryBar label="Worker capacity" value={workerCapacity} />
+        <TelemetryBar label="Host ownership" value={hostOwnership} tone={hostsOwned !== null && hostsOwned > 0 ? "danger" : "ok"} />
       </div>
 
       <div className="mini-stat-grid mt-4">
         <MiniStat title="Module runs" value={formatMetric(total)} detail={`${success} success / ${failed} failed`} icon={<Database size={16} />} />
         <MiniStat title="Findings" value={formatMetric(findings)} icon={<ShieldAlert size={16} />} />
         <MiniStat title="Queue" value={formatMetric(queueDepth)} detail={`${activeWorkers} active workers`} icon={<Layers size={16} />} />
-        <MiniStat title="Throughput" value={`${formatMetric(tasksPerMin)}/min`} detail={`${formatMetric(p95, " ms")} p95`} icon={<TrendingUp size={16} />} />
+        <MiniStat title="Throughput" value={throughputValue} detail={latencyDetail} icon={<TrendingUp size={16} />} />
       </div>
 
       <div className="telemetry-footer">
         <span><Target size={14} /> Scope: {snapshot?.campaign_id ? `campaign ${snapshot.campaign_id}` : "global"}</span>
-        <span>{hostsDiscovered} discovered / {hostsOwned} owned hosts</span>
-        <span>{unhealthyWorkers === 0 ? "workers healthy" : `${unhealthyWorkers} unhealthy workers`}</span>
+        <span>{hostsAvailable ? `${hostsDiscovered} discovered / ${hostsOwned ?? 0} owned hosts` : "Host ownership unavailable"}</span>
+        <span>{workerTotal === 0 ? "no worker sample" : unhealthyWorkers === 0 ? "workers healthy" : `${unhealthyWorkers} unhealthy workers`}</span>
       </div>
 
       <details className="advanced-details">
@@ -2705,15 +2726,15 @@ function TelemetryPanel({ snapshot, loading }: { snapshot?: TelemetrySnapshot; l
   );
 }
 
-function TelemetryBar({ label, value, tone = "ok" }: { label: string; value: number; tone?: "ok" | "danger" }) {
-  const clamped = Math.max(0, Math.min(100, value));
+function TelemetryBar({ label, value, tone = "ok" }: { label: string; value: number | null; tone?: "ok" | "danger" }) {
+  const clamped = value === null ? 0 : Math.max(0, Math.min(100, value));
   return (
-    <div className="telemetry-bar">
+    <div className="telemetry-bar" title={value === null ? "Not enough telemetry data" : undefined}>
       <span>{label}</span>
       <div className="telemetry-bar-track">
         <div className={tone === "danger" ? "telemetry-bar-fill danger" : "telemetry-bar-fill"} style={{ width: `${clamped}%` }} />
       </div>
-      <strong>{clamped}%</strong>
+      <strong>{value === null ? "n/a" : `${clamped}%`}</strong>
     </div>
   );
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -101,6 +101,7 @@ export interface MonthlyFindingStats {
   period: string;
   label: string;
   total: number;
+  confirmed_findings?: number;
   series: Array<{ date: string; count: number }>;
 }
 

--- a/tests/unit/db/test_database.py
+++ b/tests/unit/db/test_database.py
@@ -201,6 +201,7 @@ class TestDatabase:
         assert stats["period"] == datetime.now(timezone.utc).strftime("%Y-%m")
         assert stats["label"] == "Security signals this cycle"
         assert stats["total"] == 0
+        assert stats["confirmed_findings"] == 0
         assert stats["series"] == []
 
     @pytest.mark.asyncio
@@ -208,6 +209,8 @@ class TestDatabase:
         self, db: AresDatabase, campaign: Campaign
     ) -> None:
         await db.save_campaign(campaign)
+        second_campaign = Campaign(name="Second Campaign", operator="tester")
+        await db.save_campaign(second_campaign)
         month_start = datetime.now(timezone.utc).replace(
             day=1, hour=0, minute=0, second=0, microsecond=0
         )
@@ -218,8 +221,12 @@ class TestDatabase:
             "%Y-%m-%d 12:00:00"
         )
 
-        async def save_at(finding: Finding, discovered_at: str) -> None:
-            await db.save_finding(campaign.id, finding, finding.module_id)
+        async def save_at(
+            finding: Finding,
+            discovered_at: str,
+            campaign_id: str = "",
+        ) -> None:
+            await db.save_finding(campaign_id or campaign.id, finding, finding.module_id)
             await db.conn.execute(
                 "UPDATE findings SET discovered_at=? WHERE id=?",
                 (discovered_at, finding.id),
@@ -267,6 +274,17 @@ class TestDatabase:
         )
         await save_at(
             Finding(
+                title="Second campaign confirmed",
+                description="outside period in another campaign",
+                severity=Severity.HIGH,
+                validated=True,
+                module_id="test.monthly",
+            ),
+            previous_month,
+            second_campaign.id,
+        )
+        await save_at(
+            Finding(
                 title="Not validated",
                 description="filtered",
                 severity=Severity.HIGH,
@@ -292,10 +310,67 @@ class TestDatabase:
 
         assert stats["period"] == period
         assert stats["total"] == 3
+        assert stats["confirmed_findings"] == 5
         assert stats["series"] == [
             {"date": f"{period}-01", "count": 2},
             {"date": f"{period}-02", "count": 1},
         ]
+
+    @pytest.mark.asyncio
+    async def test_telemetry_stats_persist_success_failure_and_restart(
+        self, db: AresDatabase, campaign: Campaign, settings: AresSettings
+    ) -> None:
+        from ares.api.server import _is_successful_module_outcome
+
+        empty = await db.get_telemetry_stats()
+        assert empty["modules"] == {
+            "total": 0,
+            "success": 0,
+            "failed": 0,
+            "error_rate": 0.0,
+        }
+        assert empty["latency_ms"]["p95"] is None
+        assert empty["throughput"]["tasks_per_min"] is None
+        assert empty["findings"] == 0
+
+        await db.save_campaign(campaign)
+        outcomes = [
+            "modulestatus.done",
+            "done",
+            "success",
+            "partial",
+            "confirmed_findings",
+            "completed_no_findings",
+            "dry_run_ok",
+            "module_error",
+            "failed",
+        ]
+        for index, outcome in enumerate(outcomes):
+            await db.record_module_run(
+                campaign.id,
+                f"safe.{index}",
+                outcome,
+                _is_successful_module_outcome(outcome),
+                100.0 + index,
+            )
+
+        stats = await db.get_telemetry_stats()
+        assert stats["modules"]["total"] == 9
+        assert stats["modules"]["success"] == 7
+        assert stats["modules"]["failed"] == 2
+        assert stats["modules"]["error_rate"] == pytest.approx(2 / 9)
+        assert stats["latency_ms"]["p95"] == 108.0
+        assert stats["throughput"]["tasks_per_min"] == 9.0
+        assert stats["hosts"] == {"available": False, "discovered": 0, "owned": None}
+
+        reopened = await AresDatabase(db._db_path, settings.encryption_key_value).connect()
+        try:
+            restarted = await reopened.get_telemetry_stats()
+        finally:
+            await reopened.close()
+        assert restarted["modules"] == stats["modules"]
+        assert restarted["latency_ms"] == stats["latency_ms"]
+        assert restarted["findings"] == 0
 
     @pytest.mark.asyncio
     async def test_upsert_host(self, db: AresDatabase, campaign: Campaign) -> None:

--- a/tests/unit/test_api_endpoints.py
+++ b/tests/unit/test_api_endpoints.py
@@ -98,7 +98,18 @@ def _make_mock_db():
             "period": "2026-07",
             "label": "Security signals this cycle",
             "total": 0,
+            "confirmed_findings": 0,
             "series": [],
+        }
+    )
+    db.record_module_run = AsyncMock()
+    db.get_telemetry_stats = AsyncMock(
+        return_value={
+            "modules": {"total": 0, "success": 0, "failed": 0, "error_rate": 0.0},
+            "findings": 0,
+            "latency_ms": {"p50": None, "p95": None, "p99": None},
+            "throughput": {"tasks_per_min": None},
+            "hosts": {"available": False, "discovered": 0, "owned": None},
         }
     )
     db.delete_campaign = AsyncMock(return_value=False)
@@ -119,6 +130,32 @@ def _run(coro):
 
 
 # ── shared async client ───────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("outcome", "expected"),
+    [
+        ("modulestatus.done", True),
+        ("done", True),
+        ("success", True),
+        ("partial", True),
+        ("confirmed_findings", True),
+        ("completed_no_findings", True),
+        ("dry_run_ok", True),
+        ("failed", False),
+        ("error", False),
+        ("module_error", False),
+        ("operator_error", False),
+        ("dependency_error", False),
+        ("network_error", False),
+        ("timeout", False),
+        ("unsupported", False),
+    ],
+)
+def test_module_outcome_success_mapping(outcome: str, expected: bool) -> None:
+    from ares.api.server import _is_successful_module_outcome
+
+    assert _is_successful_module_outcome(outcome) is expected
 
 
 @pytest.fixture(scope="module")
@@ -196,6 +233,7 @@ class TestMonthlyStatsEndpoint:
             "period": "2026-07",
             "label": "Security signals this cycle",
             "total": 2,
+            "confirmed_findings": 2,
             "series": [{"date": "2026-07-18", "count": 2}],
         }
         db.get_monthly_confirmed_finding_stats.return_value = expected
@@ -1114,6 +1152,7 @@ class TestModuleRunEndpoint:
         class FakeResult:
             findings: list[Any] = [FakeFinding()]
             status = "done"
+            outcome = "confirmed_findings"
             duration_ms = 42.5
 
             def model_dump(self) -> dict[str, Any]:
@@ -1125,6 +1164,7 @@ class TestModuleRunEndpoint:
                     "raw_output": {},
                     "error": "",
                     "duration_ms": self.duration_ms,
+                    "outcome": self.outcome,
                 }
 
         class FakeEngine:
@@ -1141,6 +1181,14 @@ class TestModuleRunEndpoint:
 
         db.is_access_token_revoked.return_value = False
         db.save_finding = AsyncMock()
+        db.record_module_run.reset_mock()
+        db.get_telemetry_stats.return_value = {
+            "modules": {"total": 1, "success": 1, "failed": 0, "error_rate": 0.0},
+            "findings": 1,
+            "latency_ms": {"p50": 42.5, "p95": 42.5, "p99": 42.5},
+            "throughput": {"tasks_per_min": 1.0},
+            "hosts": {"available": False, "discovered": 0, "owned": None},
+        }
         db.get_campaign.return_value = {
             "id": "camp-telemetry",
             "name": "Telemetry",
@@ -1182,6 +1230,9 @@ class TestModuleRunEndpoint:
         assert snapshot["modules"]["success"] == 1
         assert snapshot["findings"] == 1
         assert snapshot["latency_ms"]["p50"] == 42.5
+        db.record_module_run.assert_awaited_once()
+        assert db.record_module_run.await_args.kwargs["outcome"] == "confirmed_findings"
+        assert db.record_module_run.await_args.kwargs["success"] is True
 
 
 class TestReportEndpoints:


### PR DESCRIPTION
## Summary
- Persist module execution telemetry in module_runs
- Derive Overview telemetry from persisted execution data
- Track module total, success, failure, duration, latency, and throughput from real runs
- Keep Findings bound to persisted confirmed findings
- Keep unsupported host ownership unavailable instead of fabricating values
- Fix success classification for confirmed_findings, completed_no_findings, dry_run_ok, done, success, and partial outcomes

## Validation
- compileall passed
- focused tests passed: 111 passed
- full unit suite passed: 1271 passed
- frontend build passed
- git diff --check passed with CRLF warnings only
- manual smoke: dashboard launched, routes returned HTTP 200, safe local module persisted telemetry

## Notes
- Manual confirmed_findings smoke was not observed because the AD lab path was unavailable, but regression tests cover successful semantic outcome classification.