### PR TITLE
docs: align Python README badge style

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ ARES is an authorized red-team engagement framework for scoped campaigns,
 module orchestration, OPSEC-aware execution, encrypted credential handling,
 and professional report generation.
 
-[![Python](https://img.shields.io/badge/Python-3.11%2B-3776AB?logo=python&logoColor=white)](https://python.org)
+[![Python](https://img.shields.io/badge/Python-3.11%2B-3776AB?style=for-the-badge&logo=python&logoColor=white)](https://python.org)
 [![FastAPI](https://img.shields.io/badge/API-FastAPI-009688?style=for-the-badge&logo=fastapi&logoColor=white)](https://fastapi.tiangolo.com)
 [![React](https://img.shields.io/badge/Dashboard-React-61DAFB?style=for-the-badge&logo=react&logoColor=111111)](https://react.dev)
 [![License](https://img.shields.io/badge/License-MIT-22C55E?style=for-the-badge)](LICENSE)


### PR DESCRIPTION
Aligns the Python README badge with the larger for-the-badge style used by the surrounding badges.

Validation:
- Only README.md changed
- Demo Video section untouched
- Other badges untouched
- git diff --check passed with CRLF warnings only