### PR TITLE
fix: define URL in frontend Vite config

### DIFF
--- a/frontend/vite.app.config.mjs
+++ b/frontend/vite.app.config.mjs
@@ -1,4 +1,5 @@
 import process from "node:process";
+import { URL } from "node:url";
 
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";


### PR DESCRIPTION
Fixes the frontend ESLint no-undef error for URL in frontend/vite.app.config.mjs.

Validation:
- Only frontend/vite.app.config.mjs changed
- ESLint passed with 0 errors
- Frontend build passed
- Frontend typecheck passed
- Frontend tests passed
- git diff --check passed with CRLF warnings only

Note:
- One existing React Hooks warning remains unrelated.